### PR TITLE
Ipad 293 diff analysis static plot dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "dependencies": {
     "gh-pages": "^3.1.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -1024,7 +1024,10 @@ class Differential extends Component {
             </Grid.Column>
           </Grid.Row>
         </Grid>
-        <div className="MultisetSvgOuter">
+        <div
+          id="differentialMultisetAnalysisSVGDiv"
+          className="MultisetSvgOuter"
+        >
           <SVG
             cacheRequests={true}
             // description=""
@@ -1036,6 +1039,7 @@ class Differential extends Component {
             // title={`${s.plotType.plotDisplay}`}
             uniqueHash="b2g9e2"
             uniquifyIDs={true}
+            id="differentialMultisetAnalysisSVG"
           />
         </div>
       </Sidebar>

--- a/src/components/Differential/DifferentialPlot.jsx
+++ b/src/components/Differential/DifferentialPlot.jsx
@@ -126,7 +126,7 @@ class DifferentialPlot extends PureComponent {
             menuItem: `${s.plotType.plotDisplay}`,
             render: () => (
               <Tab.Pane attached="true" as="div">
-                <div id="DifferentialPlotTabsPlotSVG" className="svgSpan">
+                <div id="DifferentialPlotTabsPlotSVGDiv" className="svgSpan">
                   <SVG
                     cacheRequests={true}
                     // description=""
@@ -138,6 +138,7 @@ class DifferentialPlot extends PureComponent {
                     // title={`${s.plotType.plotDisplay}`}
                     uniqueHash="c3h0f3"
                     uniquifyIDs={true}
+                    id="DifferentialPlotTabsPlotSVG"
                   />
                 </div>
               </Tab.Pane>
@@ -255,7 +256,7 @@ class DifferentialPlot extends PureComponent {
                     txtVisible={false}
                     imageInfo={imageInfoDifferential}
                     tabIndex={activeSVGTabIndexDifferentialVar}
-                    plot={'DifferentialPlotTabsPlotSVG'}
+                    plot={'DifferentialPlotTabsPlotSVGDiv'}
                   />
                 </Grid.Column>
               </Grid.Row>

--- a/src/components/Differential/DifferentialPlot.scss
+++ b/src/components/Differential/DifferentialPlot.scss
@@ -27,7 +27,7 @@
     }
   }
 }
-#DifferentialPlotTabsPlotSVG {
+#DifferentialPlotTabsPlotSVGDiv {
   width: 100% !important;
   svg {
     height: 100% !important;

--- a/src/components/Enrichment/BarcodePlot.jsx
+++ b/src/components/Enrichment/BarcodePlot.jsx
@@ -562,7 +562,7 @@ class BarcodePlot extends Component {
             pdfVisible={false}
             svgVisible={true}
             txtVisible={false}
-            plot={'BarcodeChart'}
+            plot="BarcodeChart"
             description={this.props.imageInfoEnrichment.key}
           />
         </div>

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -2183,7 +2183,7 @@ class Enrichment extends Component {
             </Grid.Column>
           </Grid.Row>
         </Grid>
-        <div className="MultisetSvgOuter">
+        <div className="MultisetSvgOuter" id="enrichmentMultisetAnalysisSVGDiv">
           <SVG
             cacheRequests={true}
             // description=""
@@ -2195,6 +2195,7 @@ class Enrichment extends Component {
             // title={`${s.plotType.plotDisplay}`}
             uniqueHash="d4i1g4"
             uniquifyIDs={true}
+            id="enrichmentMultisetAnalysisSVG"
           />
         </div>
       </Sidebar>

--- a/src/components/Enrichment/EnrichmentSVGPlot.jsx
+++ b/src/components/Enrichment/EnrichmentSVGPlot.jsx
@@ -88,7 +88,7 @@ class EnrichmentSVGPlot extends PureComponent {
               as="div"
               key={`${index}-${s.plotType.plotDisplay}-pane-enrichment`}
             >
-              <div id="EnrichmentPlotSVG" className="svgSpan">
+              <div id="EnrichmentPlotSVGDiv" className="svgSpan">
                 <SVG
                   cacheRequests={true}
                   // description=""
@@ -100,6 +100,7 @@ class EnrichmentSVGPlot extends PureComponent {
                   // title={`${s.plotType.plotDisplay}`}
                   uniqueHash="e5j2h5"
                   uniquifyIDs={true}
+                  id="EnrichmentPlotSVG"
                 />
               </div>
             </Tab.Pane>
@@ -116,7 +117,6 @@ class EnrichmentSVGPlot extends PureComponent {
   render() {
     const {
       imageInfoEnrichment,
-      imageInfoEnrichmentLength,
       svgExportName,
       tab,
       SVGPlotLoaded,
@@ -171,7 +171,7 @@ class EnrichmentSVGPlot extends PureComponent {
                 imageInfo={imageInfoEnrichment}
                 tabIndex={activeSVGTabIndexEnrichmentVar}
                 svgExportName={svgExportName}
-                plot="EnrichmentPlotSVG"
+                plot="EnrichmentPlotSVGDiv"
               />
             </div>
             {/* <Popup

--- a/src/components/Enrichment/SplitPanesContainer.scss
+++ b/src/components/Enrichment/SplitPanesContainer.scss
@@ -172,7 +172,7 @@
     flex-direction: column;
   }
 
-  #EnrichmentPlotSVG {
+  #EnrichmentPlotSVGDiv {
     // max-height: 55vh !important;
     // height: 55vh !important;
     padding-right: 45px !important;

--- a/src/components/Shared/SVGPlot.jsx
+++ b/src/components/Shared/SVGPlot.jsx
@@ -72,8 +72,10 @@ class SVGPlot extends Component {
     if (imageInfoVolcanoLength !== 0) {
       let dimensions = '';
       if (divWidth && divHeight && pxToPtRatio) {
-        const divWidthPt = roundToPrecision(divWidth / pxToPtRatio, 1);
-        const divHeightPt = roundToPrecision(divHeight / pxToPtRatio, 1);
+        const divWidthPadding = divWidth * 0.95;
+        const divHeightPadding = divHeight * 0.95;
+        const divWidthPt = roundToPrecision(divWidthPadding / pxToPtRatio, 1);
+        const divHeightPt = roundToPrecision(divHeightPadding / pxToPtRatio, 1);
         const divWidthPtString = `width=${divWidthPt}`;
         const divHeightPtString = `&height=${divHeightPt}`;
         const pointSizeString = `&pointsize=${pointSize}`;

--- a/src/components/Shared/SearchCriteria.scss
+++ b/src/components/Shared/SearchCriteria.scss
@@ -123,8 +123,8 @@
   width: 100%;
 }
 
-#enrichmentMultisetAnalysisSVG,
-#differentialMultisetAnalysisSVG {
+#enrichmentMultisetAnalysisSVGDiv,
+#differentialMultisetAnalysisSVGDiv {
   height: 100% !important;
   max-height: 75vh !important;
   width: inherit !important;

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -55,7 +55,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.1.3',
+      appVersion: '1.1.4',
       packageVersion: '',
     };
   }


### PR DESCRIPTION
This PR just adds ids to svgs that were removed when react-inlinesvg was introduced.   They are needed to fix the 5 test suite failures, as well as fix both differential and enrichment multiset export (we should add exporting of all plots to the test suite)