### PR TITLE
Add Action to trigger new release of R package.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Dispatch to trigger new release of the R package
+
+# After a new release, this Action triggers the R package repository to update
+# the pinned version of the app and create a new release.
+#
+# https://github.com/abbvie-external/OmicNavigator/releases
+# https://github.com/peter-evans/repository-dispatch
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: abbvie-external/OmicNavigator
+          event-type: app-release
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
This GitHub Action will trigger a new release of the R package bundled with the latest release of the web app.

Some requirements for this to work:

1. Both the tag and the release must be created in the GitHub UI for the action to be triggered. In other words, you can't run `git tag` locally and then later convert it to a release. @paulnordlund already creates the tags in GitHub, so this should work well.
2. The Action requires a repository secret named `REPO_ACCESS_TOKEN` that contains a PAT with repo access and is SSO authorized. @ternst23 already created and added this PAT, so it should work.

The corresponding Action in the R package repo that is triggered by this Action is [pin-app.yml](https://github.com/abbvie-external/OmicNavigator/blob/main/.github/workflows/pin-app.yml).

I had it working with my forks of the 2 repos. We'll see if it works for the next release of the web app🤞 