### PR TITLE
Add Actions to trigger deployments of main and dev branches.

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,16 @@
+name: Deploy dev branch
+on:
+  push:
+    branches:
+      - dev
+  deploy-dev:
+    if: ${{ github.repository == 'abbvie-external/OmicNavigatorWebApp' && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy dev dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: abbvie-internal/OmicNavigatorCD
+          event-type: deploy-dev
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: Deploy main branch
+on:
+  push:
+    branches:
+      - main
+  deploy-main:
+    if: ${{ github.repository == 'abbvie-external/OmicNavigatorWebApp' && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy main dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: abbvie-internal/OmicNavigatorCD
+          event-type: deploy-main
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
These Actions do the following:

* On every push to "main", it sends the dispatch signal "deploy-main" to OmicNavigatorCD, which then builds and deploys the main branches of the R package and the web app
* On every push to "dev", it sends the dispatch signal "deploy-dev" to OmicNavigatorCD, which then builds and deploys the dev branches of the R package and the web app

To do later: It would be nice to combine these files into one since they are so similar. I assume it's probably possible to insert variables into the repository_dispatch step. The only way I know to grab the branch name is by extracting it from `github.ref`, which is tedious since it returns `refs/heads/<branch-name>`