### PR TITLE
Provide more info on triggering event in dispatch payload

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,4 +14,11 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: abbvie-internal/OmicNavigatorCD
           event-type: deploy-dev
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{
+            "repository": "${{ github.repository }}",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_number": "${{ github.run_number }}"
+          }'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,4 +14,11 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: abbvie-internal/OmicNavigatorCD
           event-type: deploy-main
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{
+            "repository": "${{ github.repository }}",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_number": "${{ github.run_number }}"
+          }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,4 +17,11 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: abbvie-external/OmicNavigator
           event-type: app-release
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{
+            "repository": "${{ github.repository }}",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_number": "${{ github.run_number }}"
+          }'


### PR DESCRIPTION
I realized it's harder than it should be for out internal CD workflows to know if they were triggered by the R package or web app repos. This PR makes it so that the dispatch events include more information about the workflow that sent them.