### PR TITLE
Ipad 309 na data

### DIFF
--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -732,8 +732,20 @@ class Differential extends Component {
     };
     let differentialAlphanumericFields = [];
     let differentialNumericFields = [];
-    const firstObject = differentialResultsVar[0];
-    for (let [key, value] of Object.entries(firstObject)) {
+    function isNotNANorNullNorUndefined(o) {
+      return typeof o !== 'undefined' && o !== null && o !== 'NA';
+    }
+    function everyIsNotNANorNullNorUndefined(arr) {
+      return arr.every(isNotNANorNullNorUndefined);
+    }
+    const objectValuesArr = [...differentialResultsVar].map(f =>
+      Object.values(f),
+    );
+    const firstFullObjectIndex = objectValuesArr.findIndex(
+      everyIsNotNANorNullNorUndefined,
+    );
+    const firstFullObject = differentialResultsVar[firstFullObjectIndex];
+    for (let [key, value] of Object.entries(firstFullObject)) {
       if (typeof value === 'string' || value instanceof String) {
         differentialAlphanumericFields.push(key);
       } else {

--- a/src/components/Differential/DifferentialSearchCriteria.jsx
+++ b/src/components/Differential/DifferentialSearchCriteria.jsx
@@ -223,7 +223,7 @@ class DifferentialSearchCriteria extends Component {
             modelID: differentialModel,
             testID: differentialTest,
           };
-          const fetchUrlResultsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getResultsTable/ndjson?auto_unbox=true&digits=10`;
+          const fetchUrlResultsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getResultsTable/ndjson?auto_unbox=true&digits=10&na="string"`;
           fetch(fetchUrlResultsTable, {
             method: 'POST',
             headers: {
@@ -426,7 +426,7 @@ class DifferentialSearchCriteria extends Component {
       );
       return;
     }
-    const fetchUrlResultsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getResultsTable/ndjson?auto_unbox=true&digits=10`;
+    const fetchUrlResultsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getResultsTable/ndjson?auto_unbox=true&digits=10&na="string"`;
     fetch(fetchUrlResultsTable, {
       method: 'POST',
       headers: {
@@ -604,7 +604,7 @@ class DifferentialSearchCriteria extends Component {
       );
       return;
     }
-    const fetchUrlResultsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getResultsTable/ndjson?auto_unbox=true&digits=10`;
+    const fetchUrlResultsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getResultsTable/ndjson?auto_unbox=true&digits=10&na="string"`;
     fetch(fetchUrlResultsTable, {
       method: 'POST',
       headers: {

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -162,12 +162,24 @@ class DifferentialVolcano extends Component {
     if (this.props.differentialResults.length > 0) {
       let differentialAlphanumericFields = [];
       let relevantConfigColumns = [];
-      const firstObject = this.props.differentialResults[0];
-      for (let [key, value] of Object.entries(firstObject)) {
+      function isNotNANorNullNorUndefined(o) {
+        return typeof o !== 'undefined' && o !== null && o !== 'NA';
+      }
+      function everyIsNotNANorNullNorUndefined(arr) {
+        return arr.every(isNotNANorNullNorUndefined);
+      }
+      const objectValuesArr = [...this.props.differentialResults].map(f =>
+        Object.values(f),
+      );
+      const firstFullObjectIndex = objectValuesArr.findIndex(
+        everyIsNotNANorNullNorUndefined,
+      );
+      const firstFullObject = this.props.differentialResults[
+        firstFullObjectIndex
+      ];
+      for (let [key, value] of Object.entries(firstFullObject)) {
         if (typeof value === 'string' || value instanceof String) {
           differentialAlphanumericFields.push(key);
-        } else {
-          relevantConfigColumns.push(key);
         }
       }
       //Pushes "none" option into Volcano circle text dropdown
@@ -725,7 +737,9 @@ class DifferentialVolcano extends Component {
                       }
                       alt="Volcano Plot"
                       className={
-                        isDataStreamingResultsTable ? 'CursorNotAllowed' : ''
+                        isDataStreamingResultsTable
+                          ? 'CursorNotAllowed'
+                          : 'NoSelect'
                       }
                       id="VolcanoPlotButton"
                       onClick={
@@ -932,7 +946,7 @@ class DifferentialVolcano extends Component {
                           }
                         >
                           <Label
-                            className="MultiFeaturePlotBtn"
+                            className="MultiFeaturePlotBtn NoSelect"
                             size={dynamicSizeLarger}
                             // color="blue"
                             // image

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -290,6 +290,9 @@ class DifferentialVolcano extends Component {
     ) {
       const { differentialFeatureIdKey } = this.props;
       event.stopPropagation();
+      let sortedData =
+        this.volcanoPlotFilteredGridRef.current?.qhGridRef?.current?.data ||
+        this.props.differentialResults;
       const PreviouslyHighlighted = [
         ...this.props.HighlightedFeaturesArrVolcano,
       ];
@@ -314,7 +317,9 @@ class DifferentialVolcano extends Component {
           };
         });
         this.props.onHandleSelectedVolcano(shiftedTableDataArray);
-        this.setState({ featuresLength: shiftedTableDataArray.length || 0 });
+        this.setState({
+          featuresLength: shiftedTableDataArray.length || sortedData.length,
+        });
       } else if (event.ctrlKey) {
         const allTableData =
           this.volcanoPlotFilteredGridRef.current?.qhGridRef.current?.getSortedData() ||
@@ -326,7 +331,9 @@ class DifferentialVolcano extends Component {
             i => i.id !== item[differentialFeatureIdKey],
           );
           this.props.onHandleSelectedVolcano(selectedTableDataArray);
-          this.setState({ featuresLength: selectedTableDataArray.length || 0 });
+          this.setState({
+            featuresLength: selectedTableDataArray.length || sortedData.length,
+          });
         } else {
           // not yet highlighted, add it to array
           const indexMaxFeature = _.findIndex(allTableData, function(d) {
@@ -348,7 +355,9 @@ class DifferentialVolcano extends Component {
           }
           selectedTableDataArray = [...PreviouslyHighlighted];
           this.props.onHandleSelectedVolcano(selectedTableDataArray);
-          this.setState({ featuresLength: selectedTableDataArray.length || 0 });
+          this.setState({
+            featuresLength: selectedTableDataArray.length || sortedData.length,
+          });
         }
       } else {
         // already highlighted, remove it from array
@@ -366,7 +375,7 @@ class DifferentialVolcano extends Component {
             key: item[differentialFeatureIdKey],
           },
         ]);
-        // this.setState({ featuresLength: 1 });
+        this.setState({ featuresLength: sortedData.length || 0 });
       }
     }
   };
@@ -517,13 +526,17 @@ class DifferentialVolcano extends Component {
 
   setFeaturesLength = filteredData => {
     const { differentialResults, HighlightedFeaturesArrVolcano } = this.props;
+    let sortedData =
+      this.volcanoPlotFilteredGridRef.current?.qhGridRef?.current?.data ||
+      this.props.differentialResults;
     if (HighlightedFeaturesArrVolcano.length === 1) {
       this.setState({
         featuresLength: 1,
       });
     } else if (HighlightedFeaturesArrVolcano.length > 1) {
       this.setState({
-        featuresLength: HighlightedFeaturesArrVolcano.length || 0,
+        featuresLength:
+          HighlightedFeaturesArrVolcano.length || sortedData.length,
       });
     } else {
       let sortedData =

--- a/src/components/Differential/MetafeaturesTable.jsx
+++ b/src/components/Differential/MetafeaturesTable.jsx
@@ -45,8 +45,18 @@ class MetafeaturesTable extends Component {
       };
       let metafeaturesAlphanumericFields = [];
       let metafeaturesNumericFields = [];
-      const firstObject = data[0];
-      for (let [key, value] of Object.entries(firstObject)) {
+      function isNotNANorNullNorUndefined(o) {
+        return typeof o !== 'undefined' && o !== null && o !== 'NA';
+      }
+      function everyIsNotNANorNullNorUndefined(arr) {
+        return arr.every(isNotNANorNullNorUndefined);
+      }
+      const objectValuesArr = [...data].map(f => Object.values(f));
+      const firstFullObjectIndex = objectValuesArr.findIndex(
+        everyIsNotNANorNullNorUndefined,
+      );
+      const firstFullObject = data[firstFullObjectIndex];
+      for (let [key, value] of Object.entries(firstFullObject)) {
         if (typeof value === 'string' || value instanceof String) {
           metafeaturesAlphanumericFields.push(key);
         } else {

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -710,7 +710,6 @@ class Enrichment extends Component {
   };
 
   getConfigCols = annotationData => {
-    const enrResults = annotationData;
     const {
       enrichmentStudy,
       enrichmentModel,
@@ -732,8 +731,19 @@ class Enrichment extends Component {
     };
     let enrichmentAlphanumericFields = [];
     let enrichmentNumericFields = [];
-    const firstObject = enrResults[0];
-    for (let [key, value] of Object.entries(firstObject)) {
+    function isNotNANorNullNorUndefined(o) {
+      return typeof o !== 'undefined' && o !== null && o !== 'NA';
+    }
+
+    function everyIsNotNANorNullNorUndefined(arr) {
+      return arr.every(isNotNANorNullNorUndefined);
+    }
+    const objectValuesArr = [...annotationData].map(f => Object.values(f));
+    const firstFullObjectIndex = objectValuesArr.findIndex(
+      everyIsNotNANorNullNorUndefined,
+    );
+    const firstFullObject = annotationData[firstFullObjectIndex];
+    for (let [key, value] of Object.entries(firstFullObject)) {
       if (typeof value === 'string' || value instanceof String) {
         enrichmentAlphanumericFields.push(key);
       } else {

--- a/src/components/Enrichment/EnrichmentSearchCriteria.jsx
+++ b/src/components/Enrichment/EnrichmentSearchCriteria.jsx
@@ -233,7 +233,7 @@ class EnrichmentSearchCriteria extends Component {
             annotationID: enrichmentAnnotation,
             type: pValueType,
           };
-          const fetchUrlEnrichmentsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getEnrichmentsTable/ndjson?auto_unbox=true&digits=10`;
+          const fetchUrlEnrichmentsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getEnrichmentsTable/ndjson?auto_unbox=true&digits=10&na="string"`;
           fetch(fetchUrlEnrichmentsTable, {
             method: 'POST',
             headers: {
@@ -446,7 +446,7 @@ class EnrichmentSearchCriteria extends Component {
       annotationID: value,
       type: pValueType,
     };
-    const fetchUrlEnrichmentsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getEnrichmentsTable/ndjson?auto_unbox=true&digits=10`;
+    const fetchUrlEnrichmentsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getEnrichmentsTable/ndjson?auto_unbox=true&digits=10&na="string"`;
     fetch(fetchUrlEnrichmentsTable, {
       method: 'POST',
       headers: {
@@ -579,7 +579,7 @@ class EnrichmentSearchCriteria extends Component {
         annotationID: enrichmentAnnotation,
         type: value,
       };
-      const fetchUrlEnrichmentsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getEnrichmentsTable/ndjson?auto_unbox=true&digits=10`;
+      const fetchUrlEnrichmentsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getEnrichmentsTable/ndjson?auto_unbox=true&digits=10&na="string"`;
       fetch(fetchUrlEnrichmentsTable, {
         method: 'POST',
         headers: {
@@ -724,7 +724,7 @@ class EnrichmentSearchCriteria extends Component {
       annotationID: value,
       type: pValueType,
     };
-    const fetchUrlEnrichmentsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getEnrichmentsTable/?auto_unbox=true&digits=10`;
+    const fetchUrlEnrichmentsTable = `${this.props.baseUrl}/ocpu/library/OmicNavigator/R/getEnrichmentsTable/?auto_unbox=true&digits=10&na="string"`;
     fetch(fetchUrlEnrichmentsTable, {
       method: 'POST',
       headers: {
@@ -868,17 +868,6 @@ class EnrichmentSearchCriteria extends Component {
         cancelToken,
       )
       .then(annotationData => {
-        // let countAlphanumericFields = [];
-        // const firstObject = annotationData[0];
-        // const totalLength = Object.keys(firstObject).length;
-        // for (let [key, value] of Object.entries(firstObject)) {
-        //   if (typeof value === 'string' || value instanceof String) {
-        //     countAlphanumericFields.push(key);
-        //   }
-        // }
-        // const alphanumericLength = countAlphanumericFields.length;
-        // const annotationTestsLength = totalLength - alphanumericLength;
-        // if (reloadPlot === true && annotationTestsLength > 1) {
         const multisetResults = annotationData;
         this.setState({
           mustEnrichment,

--- a/src/components/Enrichment/FilteredDifferentialTable.jsx
+++ b/src/components/Enrichment/FilteredDifferentialTable.jsx
@@ -168,8 +168,18 @@ class FilteredDifferentialTable extends Component {
     };
     let filteredDifferentialAlphanumericFields = [];
     let filteredDifferentialNumericFields = [];
-    const firstObject = dataFromService[0];
-    for (let [key, value] of Object.entries(firstObject)) {
+    function isNotNANorNullNorUndefined(o) {
+      return typeof o !== 'undefined' && o !== null && o !== 'NA';
+    }
+    function everyIsNotNANorNullNorUndefined(arr) {
+      return arr.every(isNotNANorNullNorUndefined);
+    }
+    const objectValuesArr = [...dataFromService].map(f => Object.values(f));
+    const firstFullObjectIndex = objectValuesArr.findIndex(
+      everyIsNotNANorNullNorUndefined,
+    );
+    const firstFullObject = dataFromService[firstFullObjectIndex];
+    for (let [key, value] of Object.entries(firstFullObject)) {
       if (typeof value === 'string' || value instanceof String) {
         filteredDifferentialAlphanumericFields.push(key);
       } else {

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -145,13 +145,13 @@ export function formatNumberForDisplay(num) {
 }
 
 export function splitValue(value) {
-  if (value) {
+  if (value && value.isNaN) {
     const firstValue = value.split(';')[0];
     const numberOfSemicolons = (value.match(/;/g) || []).length;
     return numberOfSemicolons > 0
       ? `${firstValue}...(${numberOfSemicolons})`
       : firstValue;
-  }
+  } else return value;
 }
 
 export function findDomain(link) {

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -283,15 +283,9 @@ class Tabs extends Component {
               </Header>
               <p>
                 To report a bug, please open a GitHub Issue within our{' '}
-                <a
-                  className="CursorPointer"
-                  onClick={() => self.toggleInfoSecond(true)}
-                >
-                  public repository
-                </a>{' '}
-                (note that anything you write is open to the public and not
-                private to AbbVie). In your report, please include the app and
-                package versions listed above.
+                <b>public repository</b> (note that anything you write is open
+                to the public and not private to AbbVie). In your report, please
+                include the app and package versions listed above.
               </p>
               <p>
                 If you are an AbbVie employee and need to include specific

--- a/src/services/omicNavigator.service.js
+++ b/src/services/omicNavigator.service.js
@@ -16,7 +16,7 @@ class OmicNavigatorService {
     const paramsObj = params ? { digits: 10 } : {};
     const self = this;
     return new Promise(function(resolve, reject) {
-      const axiosPostUrl = `${self.url}/${method}/json?auto_unbox=true`;
+      const axiosPostUrl = `${self.url}/${method}/json?auto_unbox=true&na="string"`;
       axios
         .post(axiosPostUrl, obj, {
           params: paramsObj,


### PR DESCRIPTION
- adds "&na="string" to all non-plot calls, so opencpu returns all properties even when the values are null
- add logic to get the first object with actual values (not NA/null/undefined) to use in order to distinguish between alphanumeric and numeric columns (used for table filter types, and to determine which are tests).
- fix multi-feature plots length bug (part of IPAD-234)