### PR TITLE
Ipad 234 multi feature timeouts

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,7 +6,7 @@ import './App.scss';
 
 const App = () => (
   <div className="AppContainer">
-    <ToastContainer autoClose={5000} />
+    <ToastContainer autoClose={10000} />
     <div className="TopBar">
       <Tabs></Tabs>
     </div>

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -664,7 +664,6 @@ class Differential extends Component {
         data = [...data.slice(0, this.state.multifeaturePlotMax)];
       }
       const featureIds = data.map(featureId => featureId[key]);
-      debugger;
       this.getMultifeaturePlotTransition(featureIds, false);
     } else return;
   };

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -93,6 +93,7 @@ class Differential extends Component {
       isDataStreamingResultsTable: false,
       enableMultifeaturePlotting: false,
       updateVolcanoLabels: false,
+      multifeaturePlotMax: 1000,
     };
   }
 
@@ -660,8 +661,8 @@ class Differential extends Component {
         : differentialFeatureIdKey;
     debugger;
     if (data.length) {
-      if (data.length > 1000) {
-        data = [...data.slice(0, 999)];
+      if (data.length > this.state.mulitfeaturePlotMax) {
+        data = [...data.slice(0, this.state.mulitfeaturePlotMax)];
       }
       const featureIds = data.map(featureId => featureId[key]);
       this.getMultifeaturePlotTransition(featureIds, false);

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -610,10 +610,10 @@ class Differential extends Component {
                 plotType: multifeaturePlot[0],
                 svg: svg.data,
               };
-              const featuresLength = featureids.length;
+              const featuresLengthVar = featureids.length;
               const imageInfoVar = {
-                key: `(${featuresLength}-features)`,
-                title: `${differentialFeatureIdKey} (${featuresLength} Features)`,
+                key: `(${featuresLengthVar}-features)`,
+                title: `${differentialFeatureIdKey} (${featuresLengthVar} Features)`,
                 svg: [],
               };
               imageInfoVar.svg.push(svgInfo);
@@ -650,7 +650,7 @@ class Differential extends Component {
   handleMultifeaturePlot = (view, tableData) => {
     const { HighlightedFeaturesArrVolcano } = this.state;
     const { differentialFeatureIdKey } = this.props;
-    const data =
+    let data =
       HighlightedFeaturesArrVolcano.length > 1
         ? HighlightedFeaturesArrVolcano
         : tableData;
@@ -658,7 +658,11 @@ class Differential extends Component {
       HighlightedFeaturesArrVolcano.length > 1
         ? 'id'
         : differentialFeatureIdKey;
+    debugger;
     if (data.length) {
+      if (data.length > 1000) {
+        data = [...data.slice(0, 999)];
+      }
       const featureIds = data.map(featureId => featureId[key]);
       this.getMultifeaturePlotTransition(featureIds, false);
     } else return;

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -660,10 +660,11 @@ class Differential extends Component {
         ? 'id'
         : differentialFeatureIdKey;
     if (data.length) {
-      if (data.length > this.state.mulitfeaturePlotMax) {
-        data = [...data.slice(0, this.state.mulitfeaturePlotMax)];
+      if (data.length > this.state.multifeaturePlotMax) {
+        data = [...data.slice(0, this.state.multifeaturePlotMax)];
       }
       const featureIds = data.map(featureId => featureId[key]);
+      debugger;
       this.getMultifeaturePlotTransition(featureIds, false);
     } else return;
   };

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -488,7 +488,7 @@ class Differential extends Component {
         }
         if (returnSVG) {
           omicNavigatorService
-            .plotStudyReturnSVG(
+            .plotStudyReturnSvg(
               differentialStudy,
               differentialModel,
               id,
@@ -531,7 +531,7 @@ class Differential extends Component {
             });
         } else {
           omicNavigatorService
-            .plotStudy(
+            .plotStudyReturnSvgUrl(
               differentialStudy,
               differentialModel,
               id,
@@ -591,7 +591,7 @@ class Differential extends Component {
       );
       if (multifeaturePlot.length !== 0) {
         try {
-          const promise = omicNavigatorService.plotStudyReturnSVGWithTimeoutResolver(
+          const promise = omicNavigatorService.plotStudyReturnSvgWithTimeoutResolver(
             differentialStudy,
             differentialModel,
             featureids,
@@ -723,7 +723,7 @@ class Differential extends Component {
     );
     if (multifeaturePlot.length !== 0) {
       try {
-        const promise = omicNavigatorService.plotStudyReturnSVG(
+        const promise = omicNavigatorService.plotStudyReturnSvg(
           differentialStudy,
           differentialModel,
           featureids,

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -659,7 +659,6 @@ class Differential extends Component {
       HighlightedFeaturesArrVolcano.length > 1
         ? 'id'
         : differentialFeatureIdKey;
-    debugger;
     if (data.length) {
       if (data.length > this.state.mulitfeaturePlotMax) {
         data = [...data.slice(0, this.state.mulitfeaturePlotMax)];

--- a/src/components/Differential/DifferentialPlot.jsx
+++ b/src/components/Differential/DifferentialPlot.jsx
@@ -37,12 +37,17 @@ class DifferentialPlot extends PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    console.log(this.props.metaFeaturesDataDifferential);
-    const { imageInfoDifferentialLength, isItemSVGLoaded } = this.props;
+    const {
+      imageInfoDifferentialLength,
+      isItemSVGLoaded,
+      metaFeaturesDataDifferential,
+    } = this.props;
     const { activeSVGTabIndexDifferential } = this.state;
     if (
-      isItemSVGLoaded &&
-      prevProps.imageInfoDifferentialLength !== imageInfoDifferentialLength
+      (isItemSVGLoaded &&
+        prevProps.imageInfoDifferentialLength !==
+          imageInfoDifferentialLength) ||
+      prevProps.metaFeaturesDataDifferential !== metaFeaturesDataDifferential
     ) {
       this.getSVGPanes();
     }
@@ -99,44 +104,17 @@ class DifferentialPlot extends PureComponent {
     let panes = [];
     if (this.props.imageInfoDifferential) {
       if (this.props.imageInfoDifferential.svg.length !== 0) {
-        const pxToPtRatio = 105;
-        const pointSize = 12;
-        const width =
-          window.innerWidth ||
-          document.documentElement.clientWidth ||
-          document.body.clientWidth;
-        const height =
-          window.innerHeight ||
-          document.documentElement.clientHeight ||
-          document.body.clientHeight;
-        const divWidth = width * 0.75;
-        const divHeight = height * 0.8;
-        // const divWidth =
-        //   this.props.fwdRefDVC?.current?.offsetWidth - 15 || width - 310;
-        // const divHeight =
-        //   this.props.fwdRefDVC?.current?.offsetHeight - 115 || height - 50;
-        const divWidthPt = roundToPrecision(divWidth / pxToPtRatio, 1);
-        const divHeightPt = roundToPrecision(divHeight / pxToPtRatio, 1);
-        const divWidthPtString = `width=${divWidthPt}`;
-        const divHeightPtString = `&height=${divHeightPt}`;
-        const pointSizeString = `&pointsize=${pointSize}`;
-        const dimensions = `?${divWidthPtString}${divHeightPtString}${pointSizeString}`;
         const svgArray = [...this.props.imageInfoDifferential.svg];
         const svgPanes = svgArray.map(s => {
-          const srcUrl = `${s.svg}${dimensions}`;
           return {
             menuItem: `${s.plotType.plotDisplay}`,
             render: () => (
               <Tab.Pane attached="true" as="div">
-                <div id="DifferentialPlotTabsPlotSVGDiv" className="svgSpan">
-                  <SVG
-                    cacheRequests={true}
-                    src={srcUrl}
-                    uniqueHash="c3h0f3"
-                    uniquifyIDs={true}
-                    id="DifferentialPlotTabsPlotSVG"
-                  />
-                </div>
+                <div
+                  id="DifferentialPlotTabsPlotSVGDiv"
+                  className="svgSpan"
+                  dangerouslySetInnerHTML={{ __html: s.svg }}
+                ></div>
               </Tab.Pane>
             ),
           };
@@ -144,6 +122,7 @@ class DifferentialPlot extends PureComponent {
         panes = panes.concat(svgPanes);
       }
     }
+    debugger;
     const isMultifeaturePlot =
       this.props.imageInfoDifferential.key?.includes('features') || false;
     if (

--- a/src/components/Differential/DifferentialPlot.jsx
+++ b/src/components/Differential/DifferentialPlot.jsx
@@ -1,8 +1,6 @@
 import React, { PureComponent } from 'react';
 import { withRouter } from 'react-router-dom';
 import { Grid, Dimmer, Loader, Tab, Dropdown } from 'semantic-ui-react';
-import SVG from 'react-inlinesvg';
-import { roundToPrecision } from '../Shared/helpers';
 import DifferentialBreadcrumbs from './DifferentialBreadcrumbs';
 import ButtonActions from '../Shared/ButtonActions';
 import MetafeaturesTable from './MetafeaturesTable';
@@ -47,7 +45,8 @@ class DifferentialPlot extends PureComponent {
       (isItemSVGLoaded &&
         prevProps.imageInfoDifferentialLength !==
           imageInfoDifferentialLength) ||
-      prevProps.metaFeaturesDataDifferential !== metaFeaturesDataDifferential
+      prevProps.metaFeaturesDataDifferential.length !==
+        metaFeaturesDataDifferential.length
     ) {
       this.getSVGPanes();
     }
@@ -122,7 +121,6 @@ class DifferentialPlot extends PureComponent {
         panes = panes.concat(svgPanes);
       }
     }
-    debugger;
     const isMultifeaturePlot =
       this.props.imageInfoDifferential.key?.includes('features') || false;
     if (

--- a/src/components/Differential/DifferentialPlot.scss
+++ b/src/components/Differential/DifferentialPlot.scss
@@ -31,6 +31,7 @@
   width: 100% !important;
   svg {
     height: 100% !important;
+    max-height: 70vh !important;
     width: inherit !important;
   }
 }

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -102,7 +102,11 @@ class DifferentialVolcano extends Component {
       this.setState({
         filteredTableData: differentialResults,
         volcanoPlotRows: differentialResults?.length || 0,
-        featuresLength: limitLength(differentialResults?.length, 1000) || 0,
+        featuresLength:
+          limitLength(
+            differentialResults?.length,
+            this.props.multifeaturePlotMax,
+          ) || 0,
       });
     }
 
@@ -384,8 +388,11 @@ class DifferentialVolcano extends Component {
         this.props.onHandleSelectedVolcano(shiftedTableDataArray);
         this.setState({
           featuresLength:
-            limitLengthOrNull(shiftedTableDataArray?.length, 1000) ||
-            limitLength(sortedData?.length, 1000),
+            limitLengthOrNull(
+              shiftedTableDataArray?.length,
+              this.props.multifeaturePlotMax,
+            ) ||
+            limitLength(sortedData?.length, this.props.multifeaturePlotMax),
         });
       } else if (event.ctrlKey) {
         const allTableData =
@@ -400,8 +407,11 @@ class DifferentialVolcano extends Component {
           this.props.onHandleSelectedVolcano(selectedTableDataArray);
           this.setState({
             featuresLength:
-              limitLengthOrNull(selectedTableDataArray?.length, 1000) ||
-              limitLength(sortedData?.length, 1000),
+              limitLengthOrNull(
+                selectedTableDataArray?.length,
+                this.props.multifeaturePlotMax,
+              ) ||
+              limitLength(sortedData?.length, this.props.multifeaturePlotMax),
           });
         } else {
           // not yet highlighted, add it to array
@@ -426,8 +436,11 @@ class DifferentialVolcano extends Component {
           this.props.onHandleSelectedVolcano(selectedTableDataArray);
           this.setState({
             featuresLength:
-              limitLengthOrNull(selectedTableDataArray?.length, 1000) ||
-              limitLength(sortedData?.length, 1000),
+              limitLengthOrNull(
+                selectedTableDataArray?.length,
+                this.props.multifeaturePlotMax,
+              ) ||
+              limitLength(sortedData?.length, this.props.multifeaturePlotMax),
           });
         }
       } else {
@@ -447,7 +460,10 @@ class DifferentialVolcano extends Component {
           },
         ]);
         this.setState({
-          featuresLength: limitLength(sortedData?.length, 1000),
+          featuresLength: limitLength(
+            sortedData?.length,
+            this.props.multifeaturePlotMax,
+          ),
         });
       }
     }
@@ -622,14 +638,21 @@ class DifferentialVolcano extends Component {
     } else if (HighlightedFeaturesArrVolcano.length > 1) {
       this.setState({
         featuresLength:
-          limitLengthOrNull(HighlightedFeaturesArrVolcano?.length, 1000) ||
-          limitLength(sortedData?.length, 1000),
+          limitLengthOrNull(
+            HighlightedFeaturesArrVolcano?.length,
+            this.props.multifeaturePlotMax,
+          ) || limitLength(sortedData?.length, this.props.multifeaturePlotMax),
       });
     } else {
       let sortedData =
         this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.data ||
         differentialResults;
-      this.setState({ featuresLength: limitLength(sortedData?.length, 1000) });
+      this.setState({
+        featuresLength: limitLength(
+          sortedData?.length,
+          this.props.multifeaturePlotMax,
+        ),
+      });
     }
   };
 

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -5,7 +5,11 @@ import CustomEmptyMessage from '../Shared/Templates';
 import QHGrid, { EZGrid } from '../Shared/QHGrid';
 import DifferentialPlot from './DifferentialPlot';
 import SVGPlot from '../Shared/SVGPlot';
-import { scrollElement } from '../Shared/helpers';
+import {
+  scrollElement,
+  limitLength,
+  limitLengthOrNull,
+} from '../Shared/helpers';
 import DifferentialVolcanoPlot from './DifferentialVolcanoPlot';
 import {
   Form,
@@ -97,8 +101,8 @@ class DifferentialVolcano extends Component {
     if (prevProps.differentialResults !== differentialResults) {
       this.setState({
         filteredTableData: differentialResults,
-        volcanoPlotRows: differentialResults.length,
-        featuresLength: differentialResults.length || 0,
+        volcanoPlotRows: differentialResults?.length || 0,
+        featuresLength: limitLength(differentialResults?.length, 1000) || 0,
       });
     }
 
@@ -379,7 +383,9 @@ class DifferentialVolcano extends Component {
         });
         this.props.onHandleSelectedVolcano(shiftedTableDataArray);
         this.setState({
-          featuresLength: shiftedTableDataArray.length || sortedData.length,
+          featuresLength:
+            limitLengthOrNull(shiftedTableDataArray?.length, 1000) ||
+            limitLength(sortedData?.length, 1000),
         });
       } else if (event.ctrlKey) {
         const allTableData =
@@ -393,7 +399,9 @@ class DifferentialVolcano extends Component {
           );
           this.props.onHandleSelectedVolcano(selectedTableDataArray);
           this.setState({
-            featuresLength: selectedTableDataArray.length || sortedData.length,
+            featuresLength:
+              limitLengthOrNull(selectedTableDataArray?.length, 1000) ||
+              limitLength(sortedData?.length, 1000),
           });
         } else {
           // not yet highlighted, add it to array
@@ -417,7 +425,9 @@ class DifferentialVolcano extends Component {
           selectedTableDataArray = [...PreviouslyHighlighted];
           this.props.onHandleSelectedVolcano(selectedTableDataArray);
           this.setState({
-            featuresLength: selectedTableDataArray.length || sortedData.length,
+            featuresLength:
+              limitLengthOrNull(selectedTableDataArray?.length, 1000) ||
+              limitLength(sortedData?.length, 1000),
           });
         }
       } else {
@@ -436,7 +446,9 @@ class DifferentialVolcano extends Component {
             key: item[differentialFeatureIdKey],
           },
         ]);
-        this.setState({ featuresLength: sortedData.length || 0 });
+        this.setState({
+          featuresLength: limitLength(sortedData?.length, 1000),
+        });
       }
     }
   };
@@ -610,13 +622,14 @@ class DifferentialVolcano extends Component {
     } else if (HighlightedFeaturesArrVolcano.length > 1) {
       this.setState({
         featuresLength:
-          HighlightedFeaturesArrVolcano.length || sortedData.length,
+          limitLengthOrNull(HighlightedFeaturesArrVolcano?.length, 1000) ||
+          limitLength(sortedData?.length, 1000),
       });
     } else {
       let sortedData =
         this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.data ||
         differentialResults;
-      this.setState({ featuresLength: sortedData.length || 0 });
+      this.setState({ featuresLength: limitLength(sortedData?.length, 1000) });
     }
   };
 

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -1012,7 +1012,7 @@ class DifferentialVolcano extends Component {
                             // image
                             // basic
                             onClick={() =>
-                              this.props.onGetMultifeaturePlot(
+                              this.props.onHandleMultifeaturePlot(
                                 'Differential',
                                 tableData,
                               )

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -665,6 +665,14 @@ class DifferentialVolcano extends Component {
     } else return false;
   };
 
+  getMultiFeaturePlotBtnPopupContent = () => {
+    if (this.state.featuresLength === 1000) {
+      return 'Plot the first 1000 features in the table';
+    } else if (this.props.HighlightedFeaturesArrVolcano?.length) {
+      return `Plot the ${this.state.featuresLength} highlighted features`;
+    } else return 'Plot all of the features in the table';
+  };
+
   render() {
     const {
       filteredTableData,
@@ -1034,33 +1042,41 @@ class DifferentialVolcano extends Component {
                         <div
                           className={
                             !HasMultifeaturePlots ||
-                            isDataStreamingResultsTable ||
+                            // isDataStreamingResultsTable ||
                             HighlightedFeaturesArrVolcano.length === 1 ||
                             featuresLength === 1
                               ? 'MultifeaturePlotBtnDiv Hide'
                               : 'MultifeaturePlotBtnDiv Show'
                           }
                         >
-                          <Label
-                            className="MultiFeaturePlotBtn NoSelect"
-                            size={dynamicSizeLarger}
-                            // color="blue"
-                            // image
-                            // basic
-                            onClick={() =>
-                              this.props.onHandleMultifeaturePlot(
-                                'Differential',
-                                tableData,
-                              )
+                          <Popup
+                            trigger={
+                              <Label
+                                className="MultiFeaturePlotBtn NoSelect"
+                                size={dynamicSizeLarger}
+                                // color="blue"
+                                // image
+                                // basic
+                                onClick={() =>
+                                  this.props.onHandleMultifeaturePlot(
+                                    'Differential',
+                                    tableData,
+                                  )
+                                }
+                              >
+                                {HighlightedFeaturesArrVolcano.length !== 1
+                                  ? 'MULTI-FEATURE PLOT'
+                                  : 'SINGLE-FEATURE PLOT'}
+                                <Label.Detail className="MultiFeaturePlotDetail">
+                                  {featuresLength}
+                                </Label.Detail>
+                              </Label>
                             }
-                          >
-                            {HighlightedFeaturesArrVolcano.length !== 1
-                              ? 'MULTI-FEATURE PLOT'
-                              : 'SINGLE-FEATURE PLOT'}
-                            <Label.Detail className="MultiFeaturePlotDetail">
-                              {featuresLength}
-                            </Label.Detail>
-                          </Label>
+                            style={TableValuePopupStyle}
+                            content={this.getMultiFeaturePlotBtnPopupContent}
+                            inverted
+                            basic
+                          ></Popup>
                         </div>
                         <div className="FloatRight AbsoluteExportDifferential">
                           <ButtonActions

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -667,7 +667,9 @@ class DifferentialVolcano extends Component {
 
   getMultiFeaturePlotBtnPopupContent = () => {
     if (this.state.featuresLength === 1000) {
-      return 'Plot the first 1000 features in the table';
+      if (this.props.HighlightedFeaturesArrVolcano?.length < 1000) {
+        return 'Plot the first 1000 features in the table';
+      } else return 'Plot the first 1000 highlighted features in the table';
     } else if (this.props.HighlightedFeaturesArrVolcano?.length) {
       return `Plot the ${this.state.featuresLength} highlighted features`;
     } else return 'Plot all of the features in the table';

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -546,7 +546,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
     circles
       .attr('style', 'fill: #1678c2')
       .attr('r', 2)
-      .classed('selected', false)
       .classed('highlighted', false)
       .classed('highlightedMax', false);
 
@@ -700,9 +699,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
         d3.select(`circle[id='volcanoDataPoint-${e[this.props.identifier]}`)
           ._groups[0][0] ?? null;
       if (hoveredCircle != null) {
-        if (hoveredCircle.attributes['class'].value.endsWith('selected')) {
-          hoveredCircle.attributes['r'].value = 2.5;
-        } else if (
+        if (
           hoveredCircle.attributes['class'].value.endsWith('highlightedMax')
         ) {
           hoveredCircle.attributes['r'].value = 5;
@@ -1135,7 +1132,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
         const circles = d3.selectAll('circle.volcanoPlot-dataPoint');
         circles.attr('style', 'fill: #1678c2');
         circles.attr('r', 2);
-        circles.classed('selected', false);
         circles.classed('highlighted', false);
         circles.classed('highlightedMax', false);
 
@@ -1144,10 +1140,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
           const y = d3.select(this).attr('cy');
           return isBrushed(x, y);
         });
-
-        brushedCircles.attr('style', 'fill: #00aeff');
-        brushedCircles.attr('r', 2.5);
-        brushedCircles.classed('selected', true);
 
         const brushedDataArr = brushedCircles._groups[0].map(a => {
           return JSON.parse(a.attributes.data.value);

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -1249,6 +1249,9 @@ class DifferentialVolcanoPlot extends React.PureComponent {
         .selectAll('text')
         .remove();
 
+      // if (d3.select('#nonfiltered-elements').size() !== 0) {
+      console.log(d3.select('#nonfiltered-elements').size());
+      debugger;
       d3.select('#nonfiltered-elements')
         .selectAll('text')
         .data(brushedCircleTextMapped)

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -560,6 +560,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       volcanoDifferentialTableRowOther,
     } = this.props;
     if (d3.select('#nonfiltered-elements').size() !== 0) {
+      // set circles back to default
       d3.select('#nonfiltered-elements')
         .selectAll('circle')
         .attr('style', 'fill: #1678c2')
@@ -568,6 +569,18 @@ class DifferentialVolcanoPlot extends React.PureComponent {
         .classed('highlighted', false)
         .classed('highlightedMax', false);
     }
+
+    // set bins back to white
+    d3.select('#nonfiltered-elements')
+      .selectAll('path')
+      .attr('fill', 'white')
+      .attr('stroke', '#000')
+      .attr('d', d => `M${d.x},${d.y}${this.hexbin.hexagon(5)}`);
+
+    // determine new bin color
+    d3.select('#nonfiltered-elements')
+      .selectAll('path')
+      .attr('fill', d => this.determineBinColor(this.state.bins, d.length));
 
     if (volcanoDifferentialTableRowOther?.length > 0) {
       volcanoDifferentialTableRowOther.forEach(element => {
@@ -581,7 +594,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
               .attr('style', 'fill: #ff7e05')
               .classed('highlighted', true);
             highlightedCircle.attr('r', 5);
-            highlightedCircle.classed('highlightedMax', true);
+            highlightedCircle.classed('highlighted', true);
             highlightedCircle.raise();
           } else {
             highlightedCircle
@@ -589,7 +602,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
               .classed('highlighted', true);
             highlightedCircle.attr('stroke', '#ff7e05');
             highlightedCircle.attr('stroke-width', '#ff7e05');
-            highlightedCircle.classed('highlightedMax', true);
+            highlightedCircle.classed('highlighted', true);
             highlightedCircle.raise();
           }
         }
@@ -604,12 +617,12 @@ class DifferentialVolcanoPlot extends React.PureComponent {
           if (maxCircleId.type === 'circle') {
             maxCircle
               .attr('style', 'fill: #ff4400')
-              .classed('highlighted', true);
+              .classed('highlightedMax', true);
             maxCircle.attr('r', 5);
             maxCircle.classed('highlightedMax', true);
             maxCircle.raise();
           } else {
-            maxCircle.attr('fill', '#ff4400').classed('highlighted', true);
+            maxCircle.attr('fill', '#ff4400').classed('highlightedMax', true);
             maxCircle.attr('stroke', '#000');
             maxCircle.attr('stroke-width', 1);
             maxCircle.attr('d', d => `M${d.x},${d.y}${this.hexbin.hexagon(7)}`);

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -1251,31 +1251,44 @@ class DifferentialVolcanoPlot extends React.PureComponent {
 
       // if (d3.select('#nonfiltered-elements').size() !== 0) {
       console.log(d3.select('#nonfiltered-elements').size());
-      debugger;
       d3.select('#nonfiltered-elements')
         .selectAll('text')
         .data(brushedCircleTextMapped)
         .enter()
         .append('text')
-        .attr('key', d => `volcanoCircleText-${d.id}`)
+        .attr('key', d => {
+          if (d) {
+            return `volcanoCircleText-${d.id}`;
+          }
+        })
         .attr('class', 'volcanoCircleTooltipText')
         .attr('transform', d => {
-          const circleOnLeftSide = d.cx <= self.props.volcanoWidth / 2;
-          const cx = circleOnLeftSide ? parseInt(d.cx) + 8 : parseInt(d.cx) + 8;
-          const cy = parseInt(d.cy) + 4;
-          return `translate(${cx}, ${cy})rotate(0)`;
+          if (d) {
+            const circleOnLeftSide = d.cx <= self.props.volcanoWidth / 2;
+            const cx = circleOnLeftSide
+              ? parseInt(d.cx) + 8
+              : parseInt(d.cx) + 8;
+            const cy = parseInt(d.cy) + 4;
+            return `translate(${cx}, ${cy})rotate(0)`;
+          }
         })
         .style('font-size', '11px')
         .style('color', '#d3d3')
         .attr('textAnchor', d => {
-          const circleOnLeftSide = d.cx <= self.props.volcanoWidth / 2;
-          return circleOnLeftSide ? 'start' : 'end';
+          if (d) {
+            const circleOnLeftSide = d.cx <= self.props.volcanoWidth / 2;
+            return circleOnLeftSide ? 'start' : 'end';
+          }
         })
         .style(
           'font-family',
           'Lato, Helvetica Neue, Arial, Helvetica, sans-serif',
         )
-        .text(d => d.data);
+        .text(d => {
+          if (d) {
+            return d.data;
+          }
+        });
     }
     this.props.onUpdateVolcanoLabels(false);
   };

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _, { debounce } from 'lodash';
+import _ from 'lodash';
 import './DifferentialVolcanoPlot.scss';
 import * as d3 from 'd3';
 import * as hexbin from 'd3-hexbin';

--- a/src/components/Differential/MetafeaturesTable.jsx
+++ b/src/components/Differential/MetafeaturesTable.jsx
@@ -23,10 +23,8 @@ class MetafeaturesTable extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    console.log('table', this.props.metaFeaturesData);
     if (
-      this.props.metaFeaturesData.length !== 0 &&
-      this.props.metaFeaturesData !== prevProps.metaFeaturesData
+      this.props.metaFeaturesData.length !== prevProps.metaFeaturesData.length
     ) {
       this.getMetafeaturesTableConfigCols(this.props.metaFeaturesData);
     }

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -1197,7 +1197,6 @@ class Enrichment extends Component {
             enrichmentModel,
             id,
             enrichmentPlotTypes[i].plotID,
-            enrichmentPlotTypes[i].plotType,
             handlePlotStudyError,
             cancelToken,
           )

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -1192,7 +1192,7 @@ class Enrichment extends Component {
           return;
         }
         omicNavigatorService
-          .plotStudy(
+          .plotStudyReturnSvgUrl(
             enrichmentStudy,
             enrichmentModel,
             id,

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -206,6 +206,18 @@ export function roundToPrecision(value, precision) {
   return Math.round(value * multiplier) / multiplier;
 }
 
+export function limitLength(arrLength, length) {
+  if (arrLength) {
+    return arrLength < length ? arrLength : length;
+  } else return 0;
+}
+
+export function limitLengthOrNull(arrLength, length) {
+  if (arrLength) {
+    return arrLength < length ? arrLength : length;
+  } else return null;
+}
+
 export function networkByCluster(network) {
   network = _.cloneDeep(network);
   let buckets = [];

--- a/src/services/omicNavigator.service.js
+++ b/src/services/omicNavigator.service.js
@@ -77,34 +77,61 @@ class OmicNavigatorService {
     });
   }
 
-  // async ocpuPlotCall(method, obj, handleError, cancelToken, timeout) {
-  //   return new Promise(function(resolve, reject) {
-  //     window.ocpu
-  //       .call(method, obj, function(session) {
-  //         axios
-  //           .get(session.getLoc() + 'graphics/1/svg', {
-  //             responseType: 'text',
-  //             cancelToken,
-  //             timeout,
-  //           })
-  //           .then(response => resolve(response))
-  //           .catch(function(thrown) {
-  //             if (!axios.isCancel(thrown)) {
-  //               toast.error(`${thrown.message}`);
-  //               if (handleError != null) {
-  //                 handleError(false);
-  //               }
-  //             }
-  //           });
-  //       })
-  //       .catch(error => {
-  //         toast.error(`${error.statusText}: ${error.responseText}`);
-  //         if (handleError != null) {
-  //           handleError(false);
-  //         }
-  //       });
-  //   });
-  // }
+  async ocpuPlotCall(method, obj, handleError, cancelToken, timeout) {
+    return new Promise(function(resolve, reject) {
+      window.ocpu
+        .call(method, obj, function(session) {
+          axios
+            .get(session.getLoc() + 'graphics/1/svg', {
+              responseType: 'text',
+              cancelToken,
+              timeout,
+            })
+            .then(response => resolve(response))
+            .catch(function(thrown) {
+              if (!axios.isCancel(thrown)) {
+                toast.error(`${thrown.message}`);
+                if (handleError != null) {
+                  handleError(false);
+                }
+              }
+            });
+        })
+        .catch(error => {
+          toast.error(`${error.statusText}: ${error.responseText}`);
+          if (handleError != null) {
+            handleError(false);
+          }
+        });
+    });
+  }
+
+  async plotStudyReturnSVG(
+    study,
+    modelID,
+    featureID,
+    plotID,
+    plotType,
+    errorCb,
+    cancelToken,
+  ) {
+    this.setUrl();
+    const timeoutLength = plotType === 'multiFeature' ? 250000 : 25000;
+    const promise = this.ocpuPlotCall(
+      'plotStudy',
+      {
+        study,
+        modelID,
+        featureID,
+        plotID,
+      },
+      errorCb,
+      cancelToken,
+      timeoutLength,
+    );
+    const dataFromPromise = await promise;
+    return dataFromPromise;
+  }
 
   async ocpuRPCOutput(method, obj) {
     return new Promise(function(resolve, reject) {

--- a/src/services/omicNavigator.service.js
+++ b/src/services/omicNavigator.service.js
@@ -106,7 +106,39 @@ class OmicNavigatorService {
     });
   }
 
-  async plotStudyReturnSVG(
+  async plotStudyReturnSvgUrl(
+    study,
+    modelID,
+    featureID,
+    plotID,
+    errorCb,
+    cancelToken,
+  ) {
+    this.setUrl();
+    const timeoutLength = 60000;
+    const cacheKey = `plotStudy_${study}_${modelID}_${featureID}_${plotID}`;
+    if (this[cacheKey] != null) {
+      return this[cacheKey];
+    } else {
+      const promise = this.axiosPostPlot(
+        'plotStudy',
+        {
+          study,
+          modelID,
+          featureID,
+          plotID,
+        },
+        errorCb,
+        cancelToken,
+        timeoutLength,
+      );
+      const dataFromPromise = await promise;
+      this[cacheKey] = dataFromPromise;
+      return dataFromPromise;
+    }
+  }
+
+  async plotStudyReturnSvg(
     study,
     modelID,
     featureID,
@@ -132,7 +164,7 @@ class OmicNavigatorService {
     return dataFromPromise;
   }
 
-  async plotStudyReturnSVGWithTimeoutResolver(
+  async plotStudyReturnSvgWithTimeoutResolver(
     study,
     modelID,
     featureID,
@@ -323,31 +355,6 @@ class OmicNavigatorService {
         null,
         null,
         25000,
-      );
-      const dataFromPromise = await promise;
-      this[cacheKey] = dataFromPromise;
-      return dataFromPromise;
-    }
-  }
-
-  async plotStudy(study, modelID, featureID, plotID, errorCb, cancelToken) {
-    this.setUrl();
-    const timeoutLength = 60000;
-    const cacheKey = `plotStudy_${study}_${modelID}_${featureID}_${plotID}`;
-    if (this[cacheKey] != null) {
-      return this[cacheKey];
-    } else {
-      const promise = this.axiosPostPlot(
-        'plotStudy',
-        {
-          study,
-          modelID,
-          featureID,
-          plotID,
-        },
-        errorCb,
-        cancelToken,
-        timeoutLength,
       );
       const dataFromPromise = await promise;
       this[cacheKey] = dataFromPromise;

--- a/src/services/omicNavigator.service.js
+++ b/src/services/omicNavigator.service.js
@@ -111,12 +111,11 @@ class OmicNavigatorService {
     modelID,
     featureID,
     plotID,
-    plotType,
     errorCb,
     cancelToken,
   ) {
     this.setUrl();
-    const timeoutLength = plotType === 'multiFeature' ? 250000 : 25000;
+    const timeoutLength = 60000;
     const promise = this.ocpuPlotCall(
       'plotStudy',
       {
@@ -131,6 +130,48 @@ class OmicNavigatorService {
     );
     const dataFromPromise = await promise;
     return dataFromPromise;
+  }
+
+  async plotStudyReturnSVGWithTimeoutResolver(
+    study,
+    modelID,
+    featureID,
+    plotID,
+    errorCb,
+    cancelToken,
+  ) {
+    this.setUrl();
+    const timeoutLength = 240000;
+    // const cacheKey = `plotStudyMultifeature_${study}_${modelID}_${featureID}_${plotID}`;
+    // if (this[cacheKey] != null) {
+    //   return this[cacheKey];
+    // }
+    const promise = this.ocpuPlotCall(
+      'plotStudy',
+      {
+        study,
+        modelID,
+        featureID,
+        plotID,
+      },
+      errorCb,
+      cancelToken,
+      timeoutLength,
+    );
+    function timeoutResolver(ms) {
+      return new Promise((resolve, reject) => {
+        setTimeout(function() {
+          reject(true);
+        }, ms);
+      });
+    }
+    try {
+      await Promise.race([promise, timeoutResolver(10000)]);
+      // this[cacheKey] = promise;
+      return promise;
+    } catch (err) {
+      return err;
+    }
   }
 
   async ocpuRPCOutput(method, obj) {
@@ -289,17 +330,9 @@ class OmicNavigatorService {
     }
   }
 
-  async plotStudy(
-    study,
-    modelID,
-    featureID,
-    plotID,
-    plotType,
-    errorCb,
-    cancelToken,
-  ) {
+  async plotStudy(study, modelID, featureID, plotID, errorCb, cancelToken) {
     this.setUrl();
-    const timeoutLength = plotType === 'multiFeature' ? 250000 : 25000;
+    const timeoutLength = 60000;
     const cacheKey = `plotStudy_${study}_${modelID}_${featureID}_${plotID}`;
     if (this[cacheKey] != null) {
       return this[cacheKey];


### PR DESCRIPTION
- reverts plots in large "overlay" to call for xml and display that immediately (unlike resizable plot svgs, which return the url)
- adds race between a 10 second timeout and the multi-feature plot. If the timeout wins, a toast informs the user that the plot will open in a new tab when loaded
- limit multi-feature plotting to 1000 features
- add tooltip explaining the features to be plotted (first 1000 in table vs. all in table vs. highlighted)
- fixes shift-brush bug (nested data in "handleBrushedText")