### PR TITLE
async feature data, move to child

### DIFF
--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -88,7 +88,6 @@ class Differential extends Component {
       resultsLinkouts: [],
       resultsFavicons: [],
       isVolcanoPlotSVGLoaded: true,
-      metaFeaturesDataDifferential: [],
       allMetaFeaturesDataDifferential: [],
       isDataStreamingResultsTable: true,
       enableMultifeaturePlotting: false,
@@ -263,6 +262,7 @@ class Differential extends Component {
       .getMetaFeatures(differentialStudy, differentialModel)
       .then(getMetaFeaturesResponseData => {
         const exist = getMetaFeaturesResponseData.length > 0 ? true : false;
+        // Paul - save this data to local storage (e.g. indexDB)
         this.setState({
           modelSpecificMetaFeaturesExist: exist,
           allMetaFeaturesDataDifferential: getMetaFeaturesResponseData,
@@ -377,13 +377,7 @@ class Differential extends Component {
     });
   };
 
-  getPlotTransition = (
-    id,
-    dataItem,
-    imageInfoDifferential,
-    featureidSpecificMetaFeaturesExist,
-    useId,
-  ) => {
+  getPlotTransition = (id, dataItem, imageInfoDifferential, useId) => {
     const { differentialFeatureIdKey } = this.props;
     const differentialFeatureVar = useId
       ? id
@@ -408,13 +402,7 @@ class Differential extends Component {
           },
           false,
         );
-        self.getPlot(
-          'Differential',
-          id,
-          featureidSpecificMetaFeaturesExist,
-          false,
-          true,
-        );
+        self.getPlot('Differential', id, true);
       },
     );
   };
@@ -422,11 +410,7 @@ class Differential extends Component {
   getTableHelpers = differentialFeatureIdKeyVar => {
     const self = this;
     let addParams = {};
-    addParams.showPlotDifferential = (
-      dataItem,
-      alphanumericTrigger,
-      featureidSpecificMetaFeaturesExist,
-    ) => {
+    addParams.showPlotDifferential = (dataItem, alphanumericTrigger) => {
       return function() {
         let value = dataItem[alphanumericTrigger];
         let imageInfoDifferential = {
@@ -438,7 +422,7 @@ class Differential extends Component {
           dataItem[alphanumericTrigger],
           dataItem,
           imageInfoDifferential,
-          featureidSpecificMetaFeaturesExist,
+          false,
         );
       };
     };
@@ -446,13 +430,7 @@ class Differential extends Component {
     this.setState({ additionalTemplateInfoDifferentialTable: addParams });
   };
 
-  getPlot = (
-    view,
-    featureId,
-    featureidSpecificMetaFeaturesExist,
-    multiFeatureCall,
-    returnSVG,
-  ) => {
+  getPlot = (view, featureId, returnSVG) => {
     const { differentialPlotTypes } = this.state;
     const {
       differentialStudy,
@@ -472,15 +450,9 @@ class Differential extends Component {
     let cancelToken = new CancelToken(e => {
       cancelRequestDifferentialResultsGetPlot = e;
     });
-    if (featureidSpecificMetaFeaturesExist) {
-      this.getMetaFeaturesTable(featureId);
-    }
     if (differentialPlotTypes.length !== 0) {
       _.forEach(differentialPlotTypes, function(plot, i) {
-        if (
-          differentialPlotTypes[i].plotType === 'multiFeature' &&
-          !multiFeatureCall
-        ) {
+        if (differentialPlotTypes[i].plotType === 'multiFeature') {
           return;
         }
         if (returnSVG) {
@@ -579,9 +551,6 @@ class Differential extends Component {
       cancelRequestDifferentialResultsGetMultifeaturePlot();
       let cancelToken = new CancelToken(e => {
         cancelRequestDifferentialResultsGetMultifeaturePlot = e;
-      });
-      this.setState({
-        metaFeaturesDataDifferential: [],
       });
       let multifeaturePlot = differentialPlotTypes.filter(
         p => p.plotType === 'multiFeature',
@@ -755,37 +724,6 @@ class Differential extends Component {
     }
   }
 
-  getMetaFeaturesTable = featureId => {
-    const { differentialStudy, differentialModel } = this.props;
-    omicNavigatorService
-      .getMetaFeaturesTable(
-        differentialStudy,
-        differentialModel,
-        featureId,
-        this.handleGetMetaFeaturesTableError,
-      )
-      .then(getMetaFeaturesTableResponseData => {
-        this.setState({
-          metaFeaturesDataDifferential: getMetaFeaturesTableResponseData,
-          // areDifferentialPlotTabsReady: true,
-        });
-      })
-      .catch(error => {
-        console.error('Error during getMetaFeaturesTable', error);
-      });
-  };
-
-  handleGetMetaFeaturesTableError = () => {
-    const { differentialStudy, differentialModel } = this.props;
-    sessionStorage.setItem(
-      `${differentialStudy}-${differentialModel}-MetaFeaturesExist`,
-      false,
-    );
-    this.setState({
-      areDifferentialPlotTabsReady: true,
-    });
-  };
-
   updateDifferentialResults = results => {
     this.setState({
       differentialResults: results,
@@ -862,7 +800,7 @@ class Differential extends Component {
           isVolcanoPlotSVGLoaded: false,
           maxObjectIdentifier: maxId,
         });
-        this.getPlot('Volcano', maxId, false, false, false);
+        this.getPlot('Volcano', maxId, false);
       }
     } else {
       this.setState({
@@ -918,7 +856,6 @@ class Differential extends Component {
     const {
       resultsLinkouts,
       resultsFavicons,
-      allMetaFeaturesDataDifferential,
       differentialPlotTypes,
       modelSpecificMetaFeaturesExist,
     } = this.state;
@@ -970,7 +907,7 @@ class Differential extends Component {
         // isItemDatatLoaded: false,
         currentSVGs: [],
       });
-      this.getPlot('Differential', differentialFeature, true, false, true);
+      this.getPlot('Differential', differentialFeature, true);
     }
     this.props.onHandleDifferentialFeatureIdKey(
       'differentialFeatureIdKey',
@@ -998,24 +935,15 @@ class Differential extends Component {
           filterable: { type: 'multiFilter' },
           template: (value, item, addParams) => {
             const keyVar = `${item[f]}-${item[alphanumericTrigger]}`;
-            const mappedMetafeaturesFeatureIds = allMetaFeaturesDataDifferential.map(
-              meta => meta[alphanumericTrigger],
-            );
-            const featureidSpecificMetaFeaturesExist = mappedMetafeaturesFeatureIds.includes(
-              item[alphanumericTrigger],
-            );
+
             const featureIdClass =
-              noPlots && !featureidSpecificMetaFeaturesExist
+              noPlots && !modelSpecificMetaFeaturesExist
                 ? 'TableCellBold NoSelect'
                 : 'TableCellLink NoSelect';
             const featureIdClick =
-              noPlots && !featureidSpecificMetaFeaturesExist
+              noPlots && !modelSpecificMetaFeaturesExist
                 ? null
-                : addParams.showPlotDifferential(
-                    item,
-                    alphanumericTrigger,
-                    featureidSpecificMetaFeaturesExist,
-                  );
+                : addParams.showPlotDifferential(item, alphanumericTrigger);
             const resultsLinkoutsKeys = Object.keys(resultsLinkouts);
             let linkoutWithIcon = null;
             if (resultsLinkoutsKeys.includes(f)) {

--- a/src/components/Differential/DifferentialPlot.jsx
+++ b/src/components/Differential/DifferentialPlot.jsx
@@ -4,6 +4,7 @@ import { Grid, Dimmer, Loader, Tab, Dropdown } from 'semantic-ui-react';
 import DifferentialBreadcrumbs from './DifferentialBreadcrumbs';
 import ButtonActions from '../Shared/ButtonActions';
 import MetafeaturesTable from './MetafeaturesTable';
+import { omicNavigatorService } from '../../services/omicNavigator.service';
 // import LoaderActivePlots from '../Transitions/LoaderActivePlots';
 import '../Enrichment/SplitPanesContainer.scss';
 import '../Shared/SVGPlot.scss';
@@ -35,18 +36,11 @@ class DifferentialPlot extends PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const {
-      imageInfoDifferentialLength,
-      isItemSVGLoaded,
-      metaFeaturesDataDifferential,
-    } = this.props;
+    const { imageInfoDifferentialLength, isItemSVGLoaded } = this.props;
     const { activeSVGTabIndexDifferential } = this.state;
     if (
-      (isItemSVGLoaded &&
-        prevProps.imageInfoDifferentialLength !==
-          imageInfoDifferentialLength) ||
-      prevProps.metaFeaturesDataDifferential.length !==
-        metaFeaturesDataDifferential.length
+      isItemSVGLoaded &&
+      prevProps.imageInfoDifferentialLength !== imageInfoDifferentialLength
     ) {
       this.getSVGPanes();
     }
@@ -99,7 +93,7 @@ class DifferentialPlot extends PureComponent {
     });
   };
 
-  getSVGPanes() {
+  async getSVGPanes() {
     let panes = [];
     if (this.props.imageInfoDifferential) {
       if (this.props.imageInfoDifferential.svg.length !== 0) {
@@ -127,6 +121,14 @@ class DifferentialPlot extends PureComponent {
       this.props.modelSpecificMetaFeaturesExist !== false &&
       !isMultifeaturePlot
     ) {
+      let metaFeaturesData = await omicNavigatorService.getMetaFeaturesTable(
+        this.props.differentialStudy,
+        this.props.differentialModel,
+        this.props.differentialFeature,
+        this.handleGetMetaFeaturesTableError,
+      );
+      let metaFeaturesDataDifferential =
+        metaFeaturesData != null ? metaFeaturesData : [];
       let metafeaturesTab = [
         {
           menuItem: 'Feature Data',
@@ -134,7 +136,9 @@ class DifferentialPlot extends PureComponent {
             <Tab.Pane attached="true" as="div">
               <MetafeaturesTable
                 ref={this.metaFeaturesTableRef}
-                metaFeaturesData={this.props.metaFeaturesDataDifferential}
+                metaFeaturesData={metaFeaturesDataDifferential}
+                // differentialFeature={this.props.differentialFeature}
+                // isItemSVGLoaded={this.props.isItemSVGLoaded}
               />
             </Tab.Pane>
           ),
@@ -171,7 +175,7 @@ class DifferentialPlot extends PureComponent {
         // <LoaderActivePlots />
         <div className="PlotsMetafeaturesDimmer">
           <Dimmer active inverted>
-            <Loader size="large">Loading Plots and Feature Data...</Loader>
+            <Loader size="large">Loading...</Loader>
           </Dimmer>
         </div>
       );

--- a/src/components/Differential/MetafeaturesTable.jsx
+++ b/src/components/Differential/MetafeaturesTable.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Popup } from 'semantic-ui-react';
-// import _ from 'lodash';
+import _ from 'lodash';
 import { formatNumberForDisplay, splitValue } from '../Shared/helpers';
 import './MetafeaturesTable.scss';
 // import { CancelToken } from 'axios';
@@ -24,7 +24,12 @@ class MetafeaturesTable extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (
-      this.props.metaFeaturesData.length !== prevProps.metaFeaturesData.length
+      this.props.metaFeaturesData.length !==
+        prevProps.metaFeaturesData.length ||
+      !_.isEqual(
+        _.sortBy(this.props.metaFeaturesData),
+        _.sortBy(prevProps.metaFeaturesData),
+      )
     ) {
       this.getMetafeaturesTableConfigCols(this.props.metaFeaturesData);
     }
@@ -32,7 +37,7 @@ class MetafeaturesTable extends Component {
 
   getMetafeaturesTableConfigCols = data => {
     let configCols = [];
-    if (data.length > 0) {
+    if (data?.length > 0) {
       const TableValuePopupStyle = {
         backgroundColor: '2E2E2E',
         borderBottom: '2px solid var(--color-primary)',


### PR DESCRIPTION
- Fix feature data in the differential overlay (plots + feature data).  Sometimes the data should have existed but "getMetaFeaturesTable" wasn't called at all because "allMetaFeaturesDataDifferential" hadn't been returned.  I've moved "getMetaFeaturesTable" to a lower child component and am using async await.
- Remove unnecessary checks for "multifeature" plots, which are using multifeature specific functions recently added.
- Can test with RNAseq123, that has feature data: http://localhost:3000/#/differential/RNAseq123/Differential_Expression/BasalvsLP