### PR TITLE
Ipad 327 volcano box select behavior

### DIFF
--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -270,6 +270,7 @@ class DifferentialVolcano extends Component {
     clearHighlightedData,
   ) => {
     if (volcanoPlotSelectedDataArr.length > 0) {
+      console.log('volcano', volcanoPlotSelectedDataArr);
       this.setState({
         filteredTableData: volcanoPlotSelectedDataArr,
         volcanoPlotRows: volcanoPlotSelectedDataArr.length,
@@ -287,9 +288,13 @@ class DifferentialVolcano extends Component {
         } else this.pageToFeature();
       }
     } else {
+      // this.setState({
+      //   filteredTableData: this.props.differentialResults,
+      //   volcanoPlotRows: this.props.differentialResults.length,
+      // });
       this.setState({
-        filteredTableData: this.props.differentialResults,
-        volcanoPlotRows: this.props.differentialResults.length,
+        filteredTableData: [],
+        volcanoPlotRows: 0,
       });
     }
     // clear the highlighted rows/dots/svg

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -57,6 +57,7 @@ class DifferentialVolcano extends Component {
     animation: 'overlay',
     direction: 'right',
     visible: false,
+    volcanoCurrentState: [],
     // featuresLength: 0,
   };
   volcanoPlotFilteredGridRef = React.createRef();
@@ -95,14 +96,17 @@ class DifferentialVolcano extends Component {
       // isItemSelected,
     } = this.props;
     if (prevProps.differentialResults !== differentialResults) {
+      let data =
+        differentialResults !== this.state.volcanoCurrentState &&
+        !!this.state.volcanoCurrentState.length
+          ? this.state.volcanoCurrentState
+          : differentialResults;
+
       this.setState({
-        filteredTableData: differentialResults,
-        volcanoPlotRows: differentialResults?.length || 0,
+        filteredTableData: data,
+        volcanoPlotRows: data?.length || 0,
         featuresLength:
-          limitLength(
-            differentialResults?.length,
-            this.props.multifeaturePlotMax,
-          ) || 0,
+          limitLength(data?.length, this.props.multifeaturePlotMax) || 0,
       });
     }
 
@@ -132,6 +136,12 @@ class DifferentialVolcano extends Component {
     //   this.handlePlotAnimationVolcano('overlay');
     // }
   }
+
+  handleCurrentVolcanoCurrentState = currentState => {
+    this.setState({
+      volcanoCurrentState: currentState,
+    });
+  };
 
   pageToFeature = featureToHighlight => {
     if (featureToHighlight) {
@@ -270,7 +280,6 @@ class DifferentialVolcano extends Component {
     clearHighlightedData,
   ) => {
     if (volcanoPlotSelectedDataArr.length > 0) {
-      console.log('volcano', volcanoPlotSelectedDataArr);
       this.setState({
         filteredTableData: volcanoPlotSelectedDataArr,
         volcanoPlotRows: volcanoPlotSelectedDataArr.length,
@@ -288,10 +297,6 @@ class DifferentialVolcano extends Component {
         } else this.pageToFeature();
       }
     } else {
-      // this.setState({
-      //   filteredTableData: this.props.differentialResults,
-      //   volcanoPlotRows: this.props.differentialResults.length,
-      // });
       this.setState({
         filteredTableData: [],
         volcanoPlotRows: 0,
@@ -1028,6 +1033,9 @@ class DifferentialVolcano extends Component {
                           getMaxAndMin={this.getMaxAndMin}
                           onHandleDotClick={this.handleDotClick}
                           onPageToFeature={this.pageToFeature}
+                          onHandleVolcanoCurrentState={
+                            this.handleCurrentVolcanoCurrentState
+                          }
                         ></DifferentialVolcanoPlot>
                         <SVGPlot
                           divWidth={this.state.volcanoSvgWidth}

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -61,8 +61,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
   };
 
   setupVolcano() {
-    // console.log('setup');
-
     const {
       volcanoHeight,
       volcanoWidth,
@@ -154,7 +152,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
   }
 
   hexBinning(data) {
-    // console.log('hex binning');
     const { volcanoWidth, volcanoHeight, differentialResults } = this.props;
 
     if (data.length > 2500) {
@@ -193,7 +190,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       };
       this.setState({ ...volcanoState });
     }
-
+    this.props.onHandleVolcanoCurrentState(data);
     this.setupBrush(volcanoWidth, volcanoHeight);
 
     this.props.onHandleUpdateDifferentialResults(differentialResults);
@@ -520,7 +517,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
         this.state.currentResults.length > 0
           ? this.state.currentResults
           : differentialResultsUnfiltered;
-      this.transitionZoom(currentData, true);
+      this.transitionZoom(currentData, false);
     }
 
     if (
@@ -659,7 +656,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       .attr('fill', 'white')
       .attr('stroke', '#000')
       .attr('d', d => `M${d.x},${d.y}${this.hexbin.hexagon(5)}`);
-
     // determine new bin color
     d3.select('#nonfiltered-elements')
       .selectAll('path')
@@ -1063,7 +1059,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
     }
 
     if (isUpsetVisible) {
-      console.log('upset');
       const filteredElements = _.differenceBy(
         data,
         differentialResults,
@@ -1106,7 +1101,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
         clearHighlightedData,
       );
     } else {
-      console.log('not upset');
       if (data.length >= 2500) {
         const unfilteredObject = self.parseDataToBinsAndCircles(
           data,
@@ -1133,7 +1127,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
   }
 
   transitionZoom(data, clearHighlightedData) {
-    // console.log(' transition zoom');
     const self = this;
     const { xScale, yScale } = self.scaleFactory(data);
 
@@ -1191,6 +1184,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       .duration(100)
       .attr('opacity', 1);
 
+    this.props.onHandleVolcanoCurrentState(data);
     self.setState({
       currentResults: data,
       bins: unfilteredObject.bins,

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -655,6 +655,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       .selectAll('path')
       .attr('fill', 'white')
       .attr('stroke', '#000')
+      .attr('class', 'bin')
       .attr('d', d => `M${d.x},${d.y}${this.hexbin.hexagon(5)}`);
     // determine new bin color
     d3.select('#nonfiltered-elements')

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -1063,6 +1063,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
     }
 
     if (isUpsetVisible) {
+      console.log('upset');
       const filteredElements = _.differenceBy(
         data,
         differentialResults,
@@ -1099,11 +1100,13 @@ class DifferentialVolcanoPlot extends React.PureComponent {
         self.renderCirclesFilter(data);
         self.renderCircles(elementsToDisplay);
       }
+
       self.props.onHandleVolcanoPlotSelectionChange(
         elementsToDisplay,
         clearHighlightedData,
       );
     } else {
+      console.log('not upset');
       if (data.length >= 2500) {
         const unfilteredObject = self.parseDataToBinsAndCircles(
           data,
@@ -1230,10 +1233,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
           .flatMap(elem => elem);
 
         const circles = d3.selectAll('circle.volcanoPlot-dataPoint');
-        circles.attr('style', 'fill: #1678c2');
-        circles.attr('r', 2);
-        circles.classed('highlighted', false);
-        circles.classed('highlightedMax', false);
 
         const brushedCircles = circles.filter(function() {
           const x = d3.select(this).attr('cx');


### PR DESCRIPTION
- removes highlight code from "endBrush" function to fix gray (filtered) dots rerendering as blue
- created "volcanoCurrentState" global prop for use in "componentDidUpdate" function in DifferentialVolcano.jsx to keep table in sync with volcano plot.
- alters "setState" on line 300 to pass in empty values in order to clear the table for an empty dataset when filtered (gray) elements are box selected
- resets bin class to remove "highlighted" or "highlightedMax" if they were previously highlighted.