### PR TITLE
Ipad 303 metafeatures caching

### DIFF
--- a/src/components/Differential/DifferentialPlot.jsx
+++ b/src/components/Differential/DifferentialPlot.jsx
@@ -140,11 +140,14 @@ class DifferentialPlot extends PureComponent {
           ),
         },
       ];
+      const singleFeaturePlotTypes = this.props.differentialPlotTypes.filter(
+        p => p.plotType !== 'multiFeature',
+      );
       let metafeaturesDropdown = [
         {
           key: 'Feature-Data-Differential-Plot',
           text: 'Feature Data',
-          value: 'Feature Data',
+          value: singleFeaturePlotTypes.length,
         },
       ];
       panes = panes.concat(metafeaturesTab);
@@ -192,7 +195,7 @@ class DifferentialPlot extends PureComponent {
       ) {
         const DropdownClass =
           this.props.differentialPlotTypes.length > this.props.svgTabMax
-            ? 'Show svgPlotDropdown'
+            ? 'Show svgPlotDropdownInOverlay'
             : 'Hide svgPlotDropdown';
         const TabMenuClass =
           this.props.differentialPlotTypes.length > this.props.svgTabMax

--- a/src/components/Differential/DifferentialPlot.jsx
+++ b/src/components/Differential/DifferentialPlot.jsx
@@ -4,8 +4,6 @@ import { Grid, Dimmer, Loader, Tab, Dropdown } from 'semantic-ui-react';
 import DifferentialBreadcrumbs from './DifferentialBreadcrumbs';
 import ButtonActions from '../Shared/ButtonActions';
 import MetafeaturesTable from './MetafeaturesTable';
-import { omicNavigatorService } from '../../services/omicNavigator.service';
-// import LoaderActivePlots from '../Transitions/LoaderActivePlots';
 import '../Enrichment/SplitPanesContainer.scss';
 import '../Shared/SVGPlot.scss';
 import './DifferentialPlot.scss';
@@ -22,8 +20,7 @@ class DifferentialPlot extends PureComponent {
       pdfFlag: false,
       svgFlag: true,
       txtFlag: false,
-      // areDifferentialPlotTabsReady: false,
-      // selectedPlot: null,
+      plotOptions: [],
     };
   }
   metaFeaturesTableRef = React.createRef();
@@ -32,7 +29,6 @@ class DifferentialPlot extends PureComponent {
     const { activeSVGTabIndexDifferential } = this.state;
     this.setButtonVisibility(activeSVGTabIndexDifferential);
     this.getSVGPanes();
-    // window.addEventListener('resize', this.debouncedResizeListener);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -51,13 +47,7 @@ class DifferentialPlot extends PureComponent {
     }
   }
 
-  componentWillUnmount() {
-    // window.removeEventListener('resize', this.debouncedResizeListener);
-  }
-
-  // resizeListener() {
-  //   this.getSVGPanes();
-  // }
+  componentWillUnmount() {}
 
   setButtonVisibility = index => {
     if (this.props.differentialPlotTypes.length > 0) {
@@ -95,6 +85,7 @@ class DifferentialPlot extends PureComponent {
 
   async getSVGPanes() {
     let panes = [];
+    let options = [];
     if (this.props.imageInfoDifferential) {
       if (this.props.imageInfoDifferential.svg.length !== 0) {
         const svgArray = [...this.props.imageInfoDifferential.svg];
@@ -112,7 +103,15 @@ class DifferentialPlot extends PureComponent {
             ),
           };
         });
+        const plotOptions = svgArray.map(function(s, index) {
+          return {
+            key: `${index}=DifferentialPlotDropdownOption`,
+            text: s.plotType.plotDisplay,
+            value: index,
+          };
+        });
         panes = panes.concat(svgPanes);
+        options = options.concat(plotOptions);
       }
     }
     const isMultifeaturePlot =
@@ -121,14 +120,6 @@ class DifferentialPlot extends PureComponent {
       this.props.modelSpecificMetaFeaturesExist !== false &&
       !isMultifeaturePlot
     ) {
-      let metaFeaturesData = await omicNavigatorService.getMetaFeaturesTable(
-        this.props.differentialStudy,
-        this.props.differentialModel,
-        this.props.differentialFeature,
-        this.handleGetMetaFeaturesTableError,
-      );
-      let metaFeaturesDataDifferential =
-        metaFeaturesData != null ? metaFeaturesData : [];
       let metafeaturesTab = [
         {
           menuItem: 'Feature Data',
@@ -136,19 +127,33 @@ class DifferentialPlot extends PureComponent {
             <Tab.Pane attached="true" as="div">
               <MetafeaturesTable
                 ref={this.metaFeaturesTableRef}
-                metaFeaturesData={metaFeaturesDataDifferential}
-                // differentialFeature={this.props.differentialFeature}
-                // isItemSVGLoaded={this.props.isItemSVGLoaded}
+                differentialStudy={this.props.differentialStudy}
+                differentialModel={this.props.differentialModel}
+                differentialFeature={this.props.differentialFeature}
+                isItemSVGLoaded={this.props.isItemSVGLoaded}
+                imageInfoDifferential={this.props.imageInfoDifferential}
+                modelSpecificMetaFeaturesExist={
+                  this.props.modelSpecificMetaFeaturesExist
+                }
               />
             </Tab.Pane>
           ),
         },
       ];
+      let metafeaturesDropdown = [
+        {
+          key: 'Feature-Data-Differential-Plot',
+          text: 'Feature Data',
+          value: 'Feature Data',
+        },
+      ];
       panes = panes.concat(metafeaturesTab);
+      options = options.concat(metafeaturesDropdown);
+      // }
     }
-    // return panes;
     this.setState({
       svgPanes: panes,
+      plotOptions: options,
     });
   }
 
@@ -160,6 +165,7 @@ class DifferentialPlot extends PureComponent {
       txtFlag,
       svgFlag,
       svgPanes,
+      plotOptions,
       activeSVGTabIndexDifferential,
     } = this.state;
     const {
@@ -194,27 +200,6 @@ class DifferentialPlot extends PureComponent {
             : 'Show';
         const activeSVGTabIndexDifferentialVar =
           activeSVGTabIndexDifferential || 0;
-        let plotOptions = [];
-        if (this.props.imageInfoDifferential.length !== 0) {
-          const svgArray = [...imageInfoDifferential.svg];
-          plotOptions = svgArray.map(function(s, index) {
-            return {
-              key: `${index}=DifferentialPlotDropdownOption`,
-              text: s.plotType.plotDisplay,
-              value: index,
-            };
-          });
-          if (this.props.modelSpecificMetaFeaturesExist !== false) {
-            let metafeaturesDropdown = [
-              {
-                key: 'Feature-Data-Differential-Plot',
-                text: 'Feature Data',
-                value: 'Feature Data',
-              },
-            ];
-            plotOptions = plotOptions.concat(metafeaturesDropdown);
-          }
-        }
         return (
           <div className="PlotWrapper">
             <Grid columns={2} className="">

--- a/src/components/Shared/SVGPlot.scss
+++ b/src/components/Shared/SVGPlot.scss
@@ -9,6 +9,7 @@
     max-width: fit-content !important;
     z-index: 5 !important;
     margin-top: 0px;
+    margin-bottom: 10px !important;
   }
 
   .ui.secondary.pointing.menu {
@@ -63,4 +64,10 @@
   left: 10px !important;
   // right: 50% !important;
   cursor: pointer !important;
+}
+
+.svgPlotDropdownInOverlay {
+  max-width: fit-content !important;
+  z-index: 5 !important;
+  margin: 10px 10px 20px 10px !important;
 }


### PR DESCRIPTION
This PR does three things:
- caches the response data from getMetafeaturesTable for any given feature
- moves the getMetafeaturesTable call down to the table component itself where it is only called once (when it was higher it would get called again and again because the SVGs flow in one by one, and the call didn't have time to return/cache)
- fixes a bug with the dropdown index for "Feature Data", by reading the single plots length (filtering out multi-feature plot)
