### PR TITLE
Ipad 348 testids multitest plots

### DIFF
--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -920,7 +920,7 @@ class Differential extends Component {
     });
   };
 
-  handleSelectedVolcano = toHighlightArr => {
+  handleSelectedVolcano = (toHighlightArr, doNotUnhighlight) => {
     this.setState({
       HighlightedFeaturesArrVolcano: toHighlightArr,
     });
@@ -928,7 +928,8 @@ class Differential extends Component {
       // unhighlight single row if already highlighted
       if (
         toHighlightArr.length === 1 &&
-        this.state.volcanoDifferentialTableRowOther?.length === 0
+        this.state.volcanoDifferentialTableRowOther?.length === 0 &&
+        !doNotUnhighlight
       ) {
         if (
           toHighlightArr[0].id === this.state.volcanoDifferentialTableRowMax

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -497,10 +497,11 @@ class Differential extends Component {
           if (differentialPlotTypes[i].plotType === 'multiFeature') {
             return;
           }
-          const testsArg =
-            differentialPlotTypes[i].plotType === 'multiTest'
-              ? differentialTestIds
-              : differentialTest;
+          const testsArg = differentialPlotTypes[i].plotType.includes(
+            'multiTest',
+          )
+            ? differentialTestIds
+            : differentialTest;
           omicNavigatorService
             .plotStudyReturnSvg(
               differentialStudy,
@@ -558,10 +559,9 @@ class Differential extends Component {
             if (plot.plotType === 'multiFeature') {
               return undefined;
             }
-            const testsArg =
-              plot.plotType === 'multiTest'
-                ? differentialTestIds
-                : differentialTest;
+            const testsArg = plot.plotType.includes('multiTest')
+              ? differentialTestIds
+              : differentialTest;
             return omicNavigatorService
               .plotStudyReturnSvgUrl(
                 differentialStudy,
@@ -658,12 +658,15 @@ class Differential extends Component {
       if (multifeaturePlot.length !== 0) {
         if (multifeaturePlot.length === 1) {
           try {
+            const testsArg = multifeaturePlot[0].plotType.includes('multiTest')
+              ? differentialTestIds
+              : differentialTest;
             const promise = omicNavigatorService.plotStudyReturnSvgWithTimeoutResolver(
               differentialStudy,
               differentialModel,
               featureids,
               multifeaturePlot[0].plotID,
-              differentialTest,
+              testsArg,
               null,
               cancelToken,
             );
@@ -694,10 +697,9 @@ class Differential extends Component {
           }
         } else {
           _.forEach(multifeaturePlot, function(plot, i) {
-            const testsArg =
-              plot.plotID === 'multiTest'
-                ? differentialTestIds
-                : differentialTest;
+            const testsArg = plot.plotType.includes('multiTest')
+              ? differentialTestIds
+              : differentialTest;
 
             omicNavigatorService
               .plotStudyReturnSvg(
@@ -859,7 +861,7 @@ class Differential extends Component {
   }
 
   async getMultifeaturePlotForNewTab(featureids, plotindex) {
-    const { differentialPlotTypes } = this.state;
+    const { differentialPlotTypes, differentialTestIds } = this.state;
     const {
       differentialStudy,
       differentialModel,
@@ -873,13 +875,18 @@ class Differential extends Component {
       p => p.plotType === 'multiFeature',
     );
     if (multifeaturePlot.length !== 0) {
+      const testsArg = multifeaturePlot[plotindex].plotType.includes(
+        'multiTest',
+      )
+        ? differentialTestIds
+        : differentialTest;
       try {
         const promise = omicNavigatorService.plotStudyReturnSvg(
           differentialStudy,
           differentialModel,
           featureids,
           multifeaturePlot[plotindex].plotID,
-          differentialTest,
+          testsArg,
           null,
           cancelToken,
         );

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -83,6 +83,7 @@ class Differential extends Component {
       differentialStudyMetadata: [],
       differentialModelsAndTests: [],
       differentialTestsMetadata: [],
+      differentialTestIds: [],
       modelSpecificMetaFeaturesExist: true,
       resultsLinkouts: [],
       resultsFavicons: [],
@@ -162,6 +163,12 @@ class Differential extends Component {
   setTestsMetadata = testsData => {
     this.setState({
       differentialTestsMetadata: testsData,
+    });
+  };
+
+  setDifferentialTestIds = differentialTestIds => {
+    this.setState({
+      differentialTestIds,
     });
   };
 
@@ -464,7 +471,7 @@ class Differential extends Component {
   };
 
   getPlot = (view, featureId, returnSVG) => {
-    const { differentialPlotTypes } = this.state;
+    const { differentialPlotTypes, differentialTestIds } = this.state;
     const {
       differentialStudy,
       differentialModel,
@@ -490,13 +497,17 @@ class Differential extends Component {
           if (differentialPlotTypes[i].plotType === 'multiFeature') {
             return;
           }
+          const testsArg =
+            differentialPlotTypes[i].plotType === 'multiTest'
+              ? differentialTestIds
+              : differentialTest;
           omicNavigatorService
             .plotStudyReturnSvg(
               differentialStudy,
               differentialModel,
               id,
               differentialPlotTypes[i].plotID,
-              differentialTest,
+              testsArg,
               null,
               cancelToken,
             )
@@ -547,13 +558,17 @@ class Differential extends Component {
             if (plot.plotType === 'multiFeature') {
               return undefined;
             }
+            const testsArg =
+              plot.plotType === 'multiTest'
+                ? differentialTestIds
+                : differentialTest;
             return omicNavigatorService
               .plotStudyReturnSvgUrl(
                 differentialStudy,
                 differentialModel,
                 id,
                 plot.plotID,
-                differentialTest,
+                testsArg,
                 null,
                 cancelToken,
               )
@@ -618,7 +633,7 @@ class Differential extends Component {
 
   async getMultifeaturePlot(featureids) {
     if (featureids?.length) {
-      const { differentialPlotTypes } = this.state;
+      const { differentialPlotTypes, differentialTestIds } = this.state;
       const {
         differentialStudy,
         differentialModel,
@@ -679,13 +694,18 @@ class Differential extends Component {
           }
         } else {
           _.forEach(multifeaturePlot, function(plot, i) {
+            const testsArg =
+              plot.plotID === 'multiTest'
+                ? differentialTestIds
+                : differentialTest;
+
             omicNavigatorService
               .plotStudyReturnSvg(
                 differentialStudy,
                 differentialModel,
                 featureids,
                 multifeaturePlot[i].plotID,
-                differentialTest,
+                testsArg,
                 null,
                 cancelToken,
               )
@@ -1381,6 +1401,7 @@ class Differential extends Component {
               }
               onSetStudyModelTestMetadata={this.setStudyModelTestMetadata}
               onSetTestsMetadata={this.setTestsMetadata}
+              onSetDifferentialTestIds={this.setDifferentialTestIds}
               onHandlePlotTypesDifferential={this.handlePlotTypesDifferential}
               onHandleVolcanoTableLoading={this.handleVolcanoTableLoading}
               onDoMetaFeaturesExist={this.doMetaFeaturesExist}

--- a/src/components/Differential/DifferentialSearchCriteria.jsx
+++ b/src/components/Differential/DifferentialSearchCriteria.jsx
@@ -215,6 +215,9 @@ class DifferentialSearchCriteria extends Component {
         });
         const differentialTestsMetadataVar =
           differentialModelWithTests?.tests || [];
+        const differentialTestIdsMapped = differentialTestsMetadataVar.map(
+          test => test.testID,
+        );
         const differentialTestsMapped = differentialTestsMetadataVar.map(
           test => {
             return {
@@ -230,6 +233,7 @@ class DifferentialSearchCriteria extends Component {
           differentialTests: differentialTestsMapped,
           uDataP: uDataPMapped,
         });
+        this.props.onSetDifferentialTestIds(differentialTestIdsMapped);
         this.props.onSetTestsMetadata(differentialTestsMetadataVar);
         this.getReportLink(differentialStudy, differentialModel);
         if (differentialTest !== '') {
@@ -393,6 +397,7 @@ class DifferentialSearchCriteria extends Component {
       differentialModelTooltip: differentialModelTooltip,
       differentialTestTooltip: '',
     });
+    this.props.onSetDifferentialTestIds(differentialTestsMapped);
     this.props.onSetTestsMetadata(differentialTestsMetadataVar);
     this.getReportLink(differentialStudy, value);
   };

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -868,6 +868,7 @@ class DifferentialVolcano extends Component {
               differentialStudy={this.props.differentialStudy}
               differentialModel={this.props.differentialModel}
               differentialTest={this.props.differentialTest}
+              differentialTests={this.props.differentialTests}
             ></DifferentialPlot>
           </Sidebar>
         );

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -339,7 +339,7 @@ class DifferentialVolcano extends Component {
     );
   };
 
-  handleDotClick = (event, items, index) => {
+  handleDotClick = (event, items, index, doNotUnhighlight) => {
     const { differentialFeatureIdKey } = this.props;
     // const dotClickArr = [
     //   {
@@ -357,7 +357,7 @@ class DifferentialVolcano extends Component {
       value: item[differentialFeatureIdKey],
       key: item[differentialFeatureIdKey],
     }));
-    this.props.onHandleSelectedVolcano(elementArray);
+    this.props.onHandleSelectedVolcano(elementArray, doNotUnhighlight);
     // this.props.onHandleSelectedVolcano([
     //   {
     //     id: item[differentialFeatureIdKey],

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -1251,6 +1251,8 @@ class DifferentialVolcanoPlot extends React.PureComponent {
                   this.doTransform(a[this.props.yAxisLabel], 'y'),
               ),
             0,
+            // pass true so single selected feature is not unhighlighted
+            true,
           );
         }
 

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -350,6 +350,7 @@ class Enrichment extends Component {
       unfilteredNetworkData,
       enrichmentResults,
     } = this.state;
+    debugger;
     var arr = [...this.state.multisetTestsFilteredOut];
     if (test != null) {
       const index = arr.indexOf(test);
@@ -1215,7 +1216,7 @@ class Enrichment extends Component {
   };
 
   getPlot = featureId => {
-    const { enrichmentPlotTypes, enrichmentTest } = this.state;
+    const { enrichmentPlotTypes, enrichmentTest, uData } = this.state;
     const { enrichmentStudy, enrichmentModel } = this.props;
     let id = featureId != null ? featureId : '';
     let imageInfoEnrichmentVar = { key: '', title: '', svg: [] };
@@ -1234,13 +1235,15 @@ class Enrichment extends Component {
           if (plot.plotType === 'multiFeature') {
             return undefined;
           }
+          const testsArg =
+            plot.plotType === 'multiTest' ? uData : enrichmentTest;
           return omicNavigatorService
             .plotStudyReturnSvgUrl(
               enrichmentStudy,
               enrichmentModel,
               id,
               plot.plotID,
-              enrichmentTest,
+              testsArg,
               null,
               cancelToken,
             )

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -1235,8 +1235,9 @@ class Enrichment extends Component {
           if (plot.plotType === 'multiFeature') {
             return undefined;
           }
-          const testsArg =
-            plot.plotType === 'multiTest' ? uData : enrichmentTest;
+          const testsArg = plot.plotType.includes('multiTest')
+            ? uData
+            : enrichmentTest;
           return omicNavigatorService
             .plotStudyReturnSvgUrl(
               enrichmentStudy,

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -350,7 +350,6 @@ class Enrichment extends Component {
       unfilteredNetworkData,
       enrichmentResults,
     } = this.state;
-    debugger;
     var arr = [...this.state.multisetTestsFilteredOut];
     if (test != null) {
       const index = arr.indexOf(test);


### PR DESCRIPTION
- stores all test ids (on a study/model basis) in state, to be used for "multiTest" plot calls
- fix unintentional removal of single feature highlighting during pane drag (part of IPAD-349)