### PR TITLE
fix scatter bugs; tabs message improvement

### DIFF
--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -90,14 +90,14 @@
     .ui.celled.table tr td:first-child,
     .ui.celled.table tr th:first-child {
       min-width: 25px !important;
-      max-width: 25px !important;
+      max-width: 35px !important;
     }
 
-    .ui.celled.table tr td:last-child,
-    .ui.celled.table tr th:last-child {
-      min-width: 40px !important;
-      max-width: 40px !important;
-    }
+    // .ui.celled.table tr td:last-child,
+    // .ui.celled.table tr th:last-child {
+    //   min-width: 40px !important;
+    //   max-width: 40px !important;
+    // }
   }
 
   #DifferentialResultsTableWrapperCheckboxes,

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -88,13 +88,13 @@ class Differential extends Component {
       plotButtonActiveDifferential: false,
       multisetQueriedDifferential: false,
       upsetColsDifferential: [],
-      tabsMessage: 'Select feature/s to display plots',
+      // tabsMessage: 'Select feature/s to display plots',
       // differentialPlotTypes: [],
       differentialStudyMetadata: [],
       differentialModelsAndTests: [],
       differentialTestsMetadata: [],
       differentialTestIds: [],
-      modelSpecificMetaFeaturesExist: true,
+      modelSpecificMetaFeaturesExist: false,
       resultsLinkouts: [],
       resultsFavicons: [],
       isVolcanoPlotSVGLoaded: true,
@@ -244,7 +244,7 @@ class Differential extends Component {
         multisetPlotAvailableDifferential: false,
         imageInfoVolcano: { key: null, title: '', svg: [] },
         imageInfoDifferential: { key: null, title: '', svg: [] },
-        tabsMessage: 'Select feature/s to display plots',
+        // tabsMessage: 'Select feature/s to display plots',
         // differentialResults: [],
         // differentialResultsUnfiltered: [],
         // isItemDatatLoaded: false,
@@ -650,13 +650,13 @@ class Differential extends Component {
         }
       } else {
         if (view === 'Differential') {
-          this.setState({
-            // isItemSelected: false,
-            // isItemSVGLoaded: true,
-            // currentSVGs: [],
-            // featuresString: '',
-            tabsMessage: `No plots available for feature ${featureId}`,
-          });
+          // this.setState({
+          // isItemSelected: false,
+          // isItemSVGLoaded: true,
+          // currentSVGs: [],
+          // featuresString: '',
+          // tabsMessage: `No plots available for feature ${featureId}`,
+          // });
           this.backToTable();
           toast.error(`No plots available for feature ${featureId}`);
         } else {
@@ -669,7 +669,7 @@ class Differential extends Component {
             imageInfoVolcanoLength: 0,
             isItemSVGLoaded: true,
             isVolcanoPlotSVGLoaded: true,
-            tabsMessage: `No plots available for feature ${featureId}`,
+            // tabsMessage: `No plots available for feature ${featureId}`,
           });
           // toast.error(`No plots available for feature ${featureId}`);
         }
@@ -1085,7 +1085,7 @@ class Differential extends Component {
           imageInfoVolcanoLength: 0,
           isItemSVGLoaded: true,
           isVolcanoPlotSVGLoaded: true,
-          tabsMessage: 'Select feature/s to display plots',
+          // tabsMessage: 'Select feature/s to display plots',
         });
       }
     }
@@ -1187,7 +1187,7 @@ class Differential extends Component {
         imageInfoVolcanoLength: 0,
         isItemSVGLoaded: true,
         isVolcanoPlotSVGLoaded: true,
-        tabsMessage: 'Select feature/s to display plots',
+        // tabsMessage: 'Select feature/s to display plots',
       });
     }
   };
@@ -1210,7 +1210,6 @@ class Differential extends Component {
       differentialPlotTypes,
       modelSpecificMetaFeaturesExist,
     } = this.state;
-    // let differentialPlotTypes = [];
     const TableValuePopupStyle = {
       backgroundColor: '2E2E2E',
       borderBottom: '2px solid var(--color-primary)',
@@ -1265,21 +1264,26 @@ class Differential extends Component {
       alphanumericTrigger,
     );
     this.getTableHelpers(alphanumericTrigger);
-    const self = this;
+    const noPlots = !differentialPlotTypes.length > 0;
+    if (!noPlots && modelSpecificMetaFeaturesExist) {
+      this.setState({
+        tabsMessage: 'Select feature/s to display plots and data',
+      });
+    } else if (!noPlots) {
+      this.setState({
+        tabsMessage: 'Select feature/s to display plots',
+      });
+    } else if (modelSpecificMetaFeaturesExist) {
+      this.setState({
+        tabsMessage: 'Select feature to display data',
+      });
+    } else {
+      this.setState({
+        tabsMessage: 'No plots nor feature data available',
+      });
+    }
     const differentialAlphanumericColumnsMapped = differentialAlphanumericFields.map(
       (f, { index }) => {
-        const noPlots = differentialPlotTypes.length === 0;
-
-        if (noPlots) {
-          self.setState({
-            tabsMessage: 'No plots available',
-          });
-        }
-        if (noPlots && !modelSpecificMetaFeaturesExist) {
-          self.setState({
-            tabsMessage: 'No plots available',
-          });
-        }
         return {
           title: f,
           field: f,

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -89,6 +89,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
     volcanoCircleLabels: [],
     optionsOpen: false,
     usageOpen: false,
+    renderedOnce: false,
   };
 
   componentDidMount() {
@@ -115,6 +116,109 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       if (volcanoPlotVisible && upperPlotsVisible && !isItemSelected) {
         this.setState({ optionsOpen: true });
       }
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const {
+      volcanoDifferentialTableRowHighlight,
+      upperPlotsHeight,
+      volcanoWidth,
+      isFilteredDifferential,
+      isDataStreamingResultsTable,
+      differentialResultsUnfiltered,
+      // HighlightedFeaturesArrVolcano,
+      volcanoPlotVisible,
+      upperPlotsVisible,
+      filteredDifferentialTableData,
+      volcanoDifferentialTableRowOutline,
+      isItemSelected,
+    } = this.props;
+
+    const {
+      volcanoCircleLabel,
+      xAxisLabel,
+      yAxisLabel,
+      doXAxisTransformation,
+      doYAxisTransformation,
+    } = this.state;
+    // this if/else if/else if statement in place to minimize re-renders - should cover all situations
+    if (
+      !isDataStreamingResultsTable &&
+      isDataStreamingResultsTable !== prevProps.isDataStreamingResultsTable
+    ) {
+      this.getAxisLabels();
+      window.addEventListener('resize', this.debouncedResizeListener);
+      const dataInCurrentView =
+        this.state.currentResults.length > 0
+          ? this.state.currentResults
+          : differentialResultsUnfiltered;
+      d3.select('#VolcanoChart').remove();
+      this.setupVolcano();
+      this.hexBinning(differentialResultsUnfiltered);
+      this.transitionZoom(dataInCurrentView, false, false, false);
+      if (volcanoPlotVisible && upperPlotsVisible && !isItemSelected) {
+        this.setState({ optionsOpen: true });
+      }
+    } else if (
+      !isDataStreamingResultsTable &&
+      (prevState.xAxisLabel !== xAxisLabel ||
+        prevState.yAxisLabel !== yAxisLabel ||
+        prevState.doXAxisTransformation !== doXAxisTransformation ||
+        prevState.doYAxisTransformation !== doYAxisTransformation ||
+        prevProps.upperPlotsHeight !== upperPlotsHeight ||
+        prevProps.volcanoWidth !== volcanoWidth)
+    ) {
+      // volcano plot is open, user changes axis or height/width (visible only whe volcano plot is open)
+      d3.select('#VolcanoChart').remove();
+      this.setupVolcano();
+      this.hexBinning(this.state.currentResults);
+      this.transitionZoom(this.state.currentResults, false, false, false);
+    } else if (
+      (prevProps.isFilteredDifferential && !isFilteredDifferential) ||
+      (prevProps.isUpsetVisible && !this.props.isUpsetVisible)
+    ) {
+      // set analysis "filter" is clicked OR set analysis is toggled off
+      const dataInCurrentView =
+        this.state.currentResults.length > 0
+          ? this.state.currentResults
+          : differentialResultsUnfiltered;
+      this.transitionZoom(dataInCurrentView, false, false, false);
+    } else if (
+      !isDataStreamingResultsTable &&
+      prevProps.filteredDifferentialTableData.length !== 30 &&
+      filteredDifferentialTableData.length !==
+        prevProps.filteredDifferentialTableData.length
+    ) {
+      // table filter is applied
+      let allDataInSelectedArea =
+        this.state.currentResults.length > 0
+          ? this.state.currentResults
+          : differentialResultsUnfiltered;
+      // if (upperPlotsVisible && volcanoPlotVisible)
+      this.transitionZoom(allDataInSelectedArea, false, true, false);
+    }
+    if (volcanoCircleLabel !== prevState.volcanoCircleLabel) {
+      this.handleCircleLabels();
+    }
+    if (
+      !_.isEqual(
+        _.sortBy(volcanoDifferentialTableRowHighlight),
+        _.sortBy(prevProps.volcanoDifferentialTableRowHighlight),
+      ) ||
+      volcanoDifferentialTableRowOutline !==
+        prevProps.volcanoDifferentialTableRowOutline
+    ) {
+      this.highlightBrushedCircles();
+    }
+    if (
+      (!upperPlotsVisible &&
+        upperPlotsVisible !== prevProps.upperPlotsVisible) ||
+      (!volcanoPlotVisible &&
+        volcanoPlotVisible !== prevProps.volcanoPlotVisible)
+    ) {
+      // user closes volcano plot, close options
+      this.setState({ optionsOpen: false, usageOpen: false });
     }
   }
 
@@ -525,109 +629,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       yMax: Math.max(...yMM),
       yMin: Math.min(...yMM),
     };
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    const {
-      volcanoDifferentialTableRowHighlight,
-      upperPlotsHeight,
-      volcanoWidth,
-      isFilteredDifferential,
-      isDataStreamingResultsTable,
-      differentialResultsUnfiltered,
-      // HighlightedFeaturesArrVolcano,
-      volcanoPlotVisible,
-      upperPlotsVisible,
-      filteredDifferentialTableData,
-      volcanoDifferentialTableRowOutline,
-      isItemSelected,
-    } = this.props;
-
-    const {
-      volcanoCircleLabel,
-      xAxisLabel,
-      yAxisLabel,
-      doXAxisTransformation,
-      doYAxisTransformation,
-    } = this.state;
-    // this if/else if/else if statement in place to minimize re-renders - should cover all situations
-    if (
-      !isDataStreamingResultsTable &&
-      isDataStreamingResultsTable !== prevProps.isDataStreamingResultsTable
-    ) {
-      this.getAxisLabels();
-      window.addEventListener('resize', this.debouncedResizeListener);
-      const dataInCurrentView =
-        this.state.currentResults.length > 0
-          ? this.state.currentResults
-          : differentialResultsUnfiltered;
-      d3.select('#VolcanoChart').remove();
-      this.setupVolcano();
-      this.hexBinning(differentialResultsUnfiltered);
-      this.transitionZoom(dataInCurrentView, false, false, false);
-      if (volcanoPlotVisible && upperPlotsVisible && !isItemSelected) {
-        this.setState({ optionsOpen: true });
-      }
-    } else if (
-      !isDataStreamingResultsTable &&
-      (prevState.xAxisLabel !== xAxisLabel ||
-        prevState.yAxisLabel !== yAxisLabel ||
-        prevState.doXAxisTransformation !== doXAxisTransformation ||
-        prevState.doYAxisTransformation !== doYAxisTransformation ||
-        prevProps.upperPlotsHeight !== upperPlotsHeight ||
-        prevProps.volcanoWidth !== volcanoWidth)
-    ) {
-      // volcano plot is open, user changes axis or height/width (visible only whe volcano plot is open)
-      d3.select('#VolcanoChart').remove();
-      this.setupVolcano();
-      this.hexBinning(this.state.currentResults);
-      this.transitionZoom(this.state.currentResults, false, false, false);
-    } else if (
-      (prevProps.isFilteredDifferential && !isFilteredDifferential) ||
-      (prevProps.isUpsetVisible && !this.props.isUpsetVisible)
-    ) {
-      // set analysis "filter" is clicked OR set analysis is toggled off
-      const dataInCurrentView =
-        this.state.currentResults.length > 0
-          ? this.state.currentResults
-          : differentialResultsUnfiltered;
-      this.transitionZoom(dataInCurrentView, false, false, false);
-    } else if (
-      !isDataStreamingResultsTable &&
-      prevProps.filteredDifferentialTableData.length !== 30 &&
-      filteredDifferentialTableData.length !==
-        prevProps.filteredDifferentialTableData.length
-    ) {
-      // table filtere is applied
-      let allDataInSelectedArea =
-        this.state.currentResults.length > 0
-          ? this.state.currentResults
-          : differentialResultsUnfiltered;
-      // if (upperPlotsVisible && volcanoPlotVisible)
-      this.transitionZoom(allDataInSelectedArea, false, true, false);
-    }
-    if (volcanoCircleLabel !== prevState.volcanoCircleLabel) {
-      this.handleCircleLabels();
-    }
-    if (
-      !_.isEqual(
-        _.sortBy(volcanoDifferentialTableRowHighlight),
-        _.sortBy(prevProps.volcanoDifferentialTableRowHighlight),
-      ) ||
-      volcanoDifferentialTableRowOutline !==
-        prevProps.volcanoDifferentialTableRowOutline
-    ) {
-      this.highlightBrushedCircles();
-    }
-    if (
-      (!upperPlotsVisible &&
-        upperPlotsVisible !== prevProps.upperPlotsVisible) ||
-      (!volcanoPlotVisible &&
-        volcanoPlotVisible !== prevProps.volcanoPlotVisible)
-    ) {
-      // user closes volcano plot, close options
-      this.setState({ optionsOpen: false, usageOpen: false });
-    }
   }
 
   getCircleOrBin = key => {
@@ -1825,30 +1826,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       // DOY
       let doY = this.state.doYAxisTransformation;
       if (yLabel == null) {
-        // stored in session and available, need to set doy
-        // if (yLabel.indexOf('P_Value') >= 0) {
-        //   doY = true;
-        // } else if (yLabel.indexOf('P.Value') >= 0) {
-        //   doY = true;
-        // } else if (yLabel.indexOf('PValue') >= 0) {
-        //   doY = true;
-        // } else if (yLabel.indexOf('PVal') >= 0) {
-        //   doY = true;
-        // } else if (yLabel.indexOf('P value') >= 0) {
-        //   doY = true;
-        // } else if (yLabel.indexOf('adj_P_Val') >= 0) {
-        //   doY = true;
-        // } else if (yLabel.indexOf('adj.P.Val') >= 0) {
-        //   doY = true;
-        // } else {
-        //     // this.handleDropdownChange(
-        //     //   {},
-        //     //   { name: 'yAxisSelector', value: yLabel },
-        //     // );
-        //     doY = this.state.doYAxisTransformation;
-        //   }
-        // } else {
-        // not stored in session or available, need to set ylabel and doy
         if (relevantConfigColumns.indexOf('P_Value') >= 0) {
           yLabel = 'P_Value';
           doY = true;
@@ -1871,10 +1848,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
           yLabel = 'adj.P.Val';
           doY = true;
         } else {
-          this.handleDropdownChange(
-            {},
-            { name: 'yAxisSelector', value: relevantConfigColumns[0] },
-          );
+          yLabel = relevantConfigColumns[0];
         }
       }
       const axes = relevantConfigColumns.map(e => {
@@ -1888,8 +1862,8 @@ class DifferentialVolcanoPlot extends React.PureComponent {
         axisLabels: axes,
         yAxisLabel: yLabel,
         doYAxisTransformation: doY,
+        xAxisLabel: xLabel,
       });
-      this.handleDropdownChange({}, { name: 'xAxisSelector', value: xLabel });
     }
   };
 
@@ -1936,7 +1910,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
     } = this.state;
 
     const PlotName = `${differentialStudy}_${differentialModel}_${differentialTest}_scatter`;
-    // if (volcanoPlotVisible && upperPlotsVisible) {
     if (
       !isDataStreamingResultsTable &&
       identifier !== null &&

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -632,9 +632,10 @@ class DifferentialVolcanoPlot extends React.PureComponent {
   }
 
   getCircleOrBin = key => {
-    const { identifier, circles } = this.state;
+    const { identifier } = this.state;
+    const { differentialTableData } = this.props;
     let el = null;
-    const circleWithKey = [...circles].find(
+    const circleWithKey = [...differentialTableData].find(
       c => c[this.props.differentialFeatureIdKey] === key,
     );
     if (circleWithKey) {
@@ -1329,7 +1330,6 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       xScale,
       yScale,
     );
-
     self.setState(
       {
         currentResults: allDataInView,

--- a/src/components/Differential/SVGPlot.jsx
+++ b/src/components/Differential/SVGPlot.jsx
@@ -56,6 +56,7 @@ class SVGPlot extends Component {
       (prevProps.imageInfoVolcanoLength !== this.props.imageInfoVolcanoLength ||
         prevProps.imageInfoVolcano.key !== this.props.imageInfoVolcano.key ||
         prevProps.volcanoWidth !== this.props.volcanoWidth ||
+        prevProps.tabsMessage !== this.props.tabsMessage ||
         prevProps.upperPlotsHeight !== this.props.upperPlotsHeight)
     ) {
       this.getSVGPanes();


### PR DESCRIPTION
IPAD-375
1. results table feature blue hyperlinks active on default (displays active briefly when it shouldn't, e.g. study with "IPF.POC"), needs to change to false - modelSpecificMetaFeaturesExist: false
2. infinite "scatter plots" are loading - the Y axis label was allowed to stay null in one scenario
3. scatter plot not showing - the "Options" dropdowns used to be passed down as props, and it was slower, and Justin's code fires a change to the x axis dropdown to force a re-render. I'd moved everything down to the scatter plot level, and it's faster, so in some cases the x axis dropdown event fires, before data finishes streaming. I've adjusted the code to ensure rendering.
4. tabs message needs adjustment to look for feature data and plots, and display correct message