### PR TITLE
Ipad 349 selected plot improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2252,6 +2252,12 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -2945,6 +2951,15 @@
         "printj": "~1.1.0"
       }
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      }
+    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -3027,9 +3042,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -3449,12 +3464,12 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "axobject-query": {
@@ -10731,6 +10746,17 @@
         "requires-port": "^1.0.0"
       }
     },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "http-proxy-middleware": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
@@ -10870,6 +10896,16 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "human-signals": {
       "version": "1.1.1",
@@ -12568,13 +12604,13 @@
       "dev": true
     },
     "jsdom": {
-      "version": "16.5.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
-      "integrity": "sha512-Qj1H+PEvUsOtdPJ056ewXM4UJPCi4hhLA8wpiz9F2YvsRBhuFsXxtrIFAgGBDynQA9isAMGE91PfUYbdMPXuTA==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "dev": true,
       "requires": {
         "abab": "^2.0.5",
-        "acorn": "^8.1.0",
+        "acorn": "^8.2.4",
         "acorn-globals": "^6.0.0",
         "cssom": "^0.4.4",
         "cssstyle": "^2.3.0",
@@ -12582,12 +12618,13 @@
         "decimal.js": "^10.2.1",
         "domexception": "^2.0.1",
         "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
         "html-encoding-sniffer": "^2.0.1",
-        "is-potential-custom-element-name": "^1.0.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
         "nwsapi": "^2.2.0",
         "parse5": "6.0.1",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "saxes": "^5.0.1",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.0.0",
@@ -12597,14 +12634,14 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.4",
+        "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "8.2.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
-          "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+          "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
           "dev": true
         },
         "escodegen": {
@@ -12621,10 +12658,21 @@
           }
         },
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
+        },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
         },
         "levn": {
           "version": "0.3.0",
@@ -13894,6 +13942,12 @@
           "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
           "dev": true
         },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -13925,6 +13979,12 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "js-yaml": {
           "version": "3.13.1",
@@ -13979,6 +14039,25 @@
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -14001,6 +14080,15 @@
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
           }
         }
       }
@@ -17842,26 +17930,6 @@
         "uuid": "^3.3.2"
       }
     },
-    "request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.19"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "dev": true,
-      "requires": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -19580,12 +19648,6 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
-    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -20238,9 +20300,9 @@
       "dev": true
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-arraybuffer": {
@@ -22208,45 +22270,12 @@
       "dev": true
     },
     "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "wmf": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "private": true,
   "dependencies": {
     "d3-hexbin": "^0.2.2",
@@ -47,7 +47,7 @@
     "@observablehq/stdlib": "^3.3.0",
     "airbnb-prop-types": "^2.13.2",
     "array-move": "^2.2.1",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "blob-stream": "^0.1.3",
     "can-ndjson-stream": "^1.0.2",
     "canvg": "^3.0.7",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -1,12 +1,14 @@
 :root {
   // --color-primary: #ff4400;
   --color-primary: rgba(255, 68, 0, 1);
+  --color-primary-half: rgba(255, 68, 0, 0.5);
   // --color-primary-gradient: #ff7e38;
   --color-primary-gradient: rgba(255, 126, 5, 1);
   --color-secondary: rgba(44, 59, 120, 1);
   --color-secondary-gradient: #94959c;
   --color-tertiary: #00aeff;
   --color-link: rgba(22, 120, 194, 1) !important;
+  --color-link-half: rgba(22, 120, 194, 0.5) !important;
   --color-white: #fff;
   --color-light: #e0e1e2;
   --color-dark: #2e2e2e;
@@ -68,6 +70,16 @@
     padding-right: 10px !important;
   }
 
+  .QHGrid table td:not(:first-child):hover {
+    border-top: 3px solid var(--color-link-half) !important;
+    border-bottom: 3px solid var(--color-link-half) !important;
+  }
+
+  .QHGrid table thead:hover {
+    border-top: none !important;
+    border-bottom: none !important;
+  }
+
   .QHGrid table tr th:first-child {
     background-color: #fff !important;
     //   padding-right: 0px !important;
@@ -93,6 +105,23 @@
       max-width: 35px !important;
     }
 
+    .ui.celled.table tr td:first-child:hover,
+    .ui.celled.table tr th:first-child:hover {
+      cursor: cell;
+      // border-top: 3px solid var(--color-primary-half) !important;
+      // border-top: none !important;
+      // border-bottom: 3px solid var(--color-primary-half) !important;
+      // border-bottom: none !important;
+      color: var(--color-primary-half) !important;
+    }
+    .ui.celled.table tr th:first-child:hover i.icon.square.outline:before {
+      content: '\f14a';
+      color: var(--color-primary) !important;
+    }
+
+    .ui.celled.table tr th:first-child:hover i.icon.square.outline:after {
+      background-color: var(--color-primary) !important;
+    }
     // .ui.celled.table tr td:last-child,
     // .ui.celled.table tr th:last-child {
     //   min-width: 40px !important;

--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -114,14 +114,6 @@
       // border-bottom: none !important;
       color: var(--color-primary-half) !important;
     }
-    .ui.celled.table tr th:first-child:hover i.icon.square.outline:before {
-      content: '\f14a';
-      color: var(--color-primary) !important;
-    }
-
-    .ui.celled.table tr th:first-child:hover i.icon.square.outline:after {
-      background-color: var(--color-primary) !important;
-    }
     // .ui.celled.table tr td:last-child,
     // .ui.celled.table tr th:last-child {
     //   min-width: 40px !important;

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -1409,10 +1409,7 @@ class Differential extends Component {
           // self.state.volcanoDifferentialTableRowHighlight.contains(item),
           template: (value, item, addParams) => {
             return (
-              <div
-                id="ViewPlotCol"
-                className="DifferentialResultsRowCheckboxDiv"
-              >
+              <div className="DifferentialResultsRowCheckboxDiv">
                 <Icon
                   name="square outline"
                   size="large"

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -230,6 +230,9 @@ class DifferentialVolcano extends Component {
     if (clearHighlightedData) {
       this.pageToFeature();
       this.props.onHandleSelectedVolcano([]);
+      this.setState({
+        differentialTableData: volcanoPlotSelectedDataArr,
+      });
       return;
     }
     let allFeatureIdsRemaining = [...volcanoPlotSelectedDataArr].map(
@@ -239,9 +242,19 @@ class DifferentialVolcano extends Component {
       this.props.volcanoDifferentialTableRowOutline,
     );
     if (volcanoPlotSelectedDataArr.length > 0) {
+      let sortedData =
+        this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.getSortedData() ||
+        this.props.differentialResults;
+      // const sortDataIds = [...sortedData].map(d => d[this.props.differentialFeatureIdKey]);
+      const volcanoPlotDataArrIds = [...volcanoPlotSelectedDataArr].map(
+        d => d[this.props.differentialFeatureIdKey],
+      );
+      const matchCurrentTableOrder = [...sortedData].filter(d =>
+        volcanoPlotDataArrIds.includes(d[this.props.differentialFeatureIdKey]),
+      );
       const self = this;
       this.setState({
-        differentialTableData: volcanoPlotSelectedDataArr,
+        differentialTableData: matchCurrentTableOrder,
         volcanoPlotRows: volcanoPlotSelectedDataArr.length,
       });
       let multiselectedFeaturesArrRemaining = [

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -454,7 +454,14 @@ class DifferentialVolcano extends Component {
       differentialResults,
     } = this.props;
     const { hasMultifeaturePlots } = this.state;
+    event.persist();
     event.stopPropagation();
+    // console.log('className', event.target.className);
+    // console.log('classList', event.target.classList);
+    // console.log('Event', { event });
+    // console.log(event?.target?.classList?.contains('DifferentialResultsRowCheckbox'));
+    // console.log(event?.target?.classList?.contains('DifferentialResultsRowCheckboxDiv'));
+    // console.log(event?.target?.innerHTML.includes('DifferentialResultsRowCheckboxDiv'));
     if (
       item == null ||
       event?.target?.className === 'ExternalSiteIcon' ||
@@ -477,7 +484,6 @@ class DifferentialVolcano extends Component {
       if (volcanoDifferentialTableRowOutline !== '') {
         baseFeature = volcanoDifferentialTableRowOutline;
       }
-
       if (event.shiftKey) {
         if (!hasMultifeaturePlots) return;
         const currentTableData =
@@ -523,7 +529,10 @@ class DifferentialVolcano extends Component {
         event.ctrlKey ||
         event.metaKey ||
         event?.target?.classList?.contains('DifferentialResultsRowCheckbox') ||
-        event?.target?.classList?.contains('DifferentialResultsRowCheckboxDiv')
+        event?.target?.classList?.contains(
+          'DifferentialResultsRowCheckboxDiv',
+        ) ||
+        event?.target?.innerHTML.includes('DifferentialResultsRowCheckboxDiv')
       ) {
         if (!hasMultifeaturePlots) return;
         // control-click or click specifically on checkbox

--- a/src/components/Differential/DifferentialVolcano.jsx
+++ b/src/components/Differential/DifferentialVolcano.jsx
@@ -972,16 +972,9 @@ class DifferentialVolcano extends Component {
     };
     const SelectAllPopupContent = (
       <List inverted>
-        {/* <List.Item>
-          <Icon name="square outline" />
-          <List.Content>
-            <List.Header>Select All</List.Header>
-            <List.Description>
-              Click box to left, to select/deselect first{' '}
-              {this.props.multifeaturePlotMax} checkboxes
-            </List.Description>
-          </List.Content>
-        </List.Item> */}
+        <List.Header id="MultiSelectColumnHeader">
+          Multi-Select Column
+        </List.Header>
         <List.Item>
           <Icon name="check square outline" />
           <List.Content>

--- a/src/components/Differential/DifferentialVolcano.scss
+++ b/src/components/Differential/DifferentialVolcano.scss
@@ -372,3 +372,9 @@
 .th-select {
   position: relative;
 }
+
+#MultiSelectColumnHeader {
+  font-size: 15px;
+  margin: 0 auto;
+  padding-bottom: 10px;
+}

--- a/src/components/Differential/DifferentialVolcanoPlot.jsx
+++ b/src/components/Differential/DifferentialVolcanoPlot.jsx
@@ -332,7 +332,7 @@ class DifferentialVolcanoPlot extends React.PureComponent {
       });
 
     svg.on('dblclick', () => {
-      this.transitionZoom(differentialResultsUnfiltered, false, false, true);
+      this.transitionZoom(differentialResultsUnfiltered, true, false, true);
     });
   }
 

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.3.4',
+      appVersion: '1.4.0',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
1) Added "Multi-Select Column" header to the multi-select column tooltip
2) Using a "cell" cursor and making checkbox outline orange 50% opacity when hovering in multi-select column.
3) when hovering over a cell, displaying a blue outline 50% opacity.  I could do the entire row like that, but the trade-off is that the multi-select cell hover will also trigger that effect, which is misleading (note there is no row onHover event built into QHGrid now).  I didn't find a way to override parent css, from a child.
4) B.E.'s top concern was that when the user has things highlighted/outlined (with no table sorting used), and then zooms in the scatter plot, the highlighted/outlined rows always get pushed to the bottom of the table/last page.  NOTE: this issue is not new, it exists in .141 with the old code.  The D3 scatter endBrush event (DifferentialVolcanoPlot.jsx, line 1463) selects all "circle.volcanoPlot-dataPoint", and the circle with "highlighted" or "outlined" and that class get pushed last, after the other circles.  This data is then passed up the parent for handling, and that's where I am comparing the sortedTable data to it, and maintaining the sortedTable data that's applicable.