### PR TITLE
improve table row hover, fix scope, bump to v1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12752,9 +12752,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -12830,14 +12830,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "dependencies": {
     "d3-hexbin": "^0.2.2",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -70,11 +70,6 @@
     padding-right: 10px !important;
   }
 
-  .QHGrid table td:not(:first-child):hover {
-    border-top: 3px solid var(--color-link-half) !important;
-    border-bottom: 3px solid var(--color-link-half) !important;
-  }
-
   .QHGrid table thead:hover {
     border-top: none !important;
     border-bottom: none !important;
@@ -119,6 +114,16 @@
     //   min-width: 40px !important;
     //   max-width: 40px !important;
     // }
+
+    .QHGrid table td:not(:first-child):hover {
+      border-top: 3px solid var(--color-link-half) !important;
+      border-bottom: 3px solid var(--color-link-half) !important;
+    }
+
+    .QHGrid table td:not(:first-child):hover ~ td {
+      border-top: 3px solid var(--color-link-half) !important;
+      border-bottom: 3px solid var(--color-link-half) !important;
+    }
   }
 
   #DifferentialResultsTableWrapperCheckboxes,
@@ -132,6 +137,22 @@
         margin-left: 0px !important;
         // margin-top: -3px !important;
       }
+    }
+  }
+  #DifferentialResultsTableWrapper {
+    .QHGrid table {
+      border-collapse: collapse;
+      tr {
+        cursor: pointer !important;
+      }
+      .QHGrid--generalSearch:nth-child(1) {
+        margin-left: 0px !important;
+        // margin-top: -3px !important;
+      }
+    }
+    .QHGrid table tbody tr:hover {
+      border-top: 3px solid var(--color-link-half) !important;
+      border-bottom: 3px solid var(--color-link-half) !important;
     }
   }
 

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.4.0',
+      appVersion: '1.4.1',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
- Fix CSS so the two tables in enrichment tab are not in scope
- Improve hover behavior: if multi-feature plotting is not available, add outline to entire row; if multi-feature plotting is available, add outline to cell (not first, which is the checkbox) and to adjacent cells: td:not(:first-child):hover ~ td. Note, this was the best solution without having to adjust external quick hits grid code, since in CSS children cannot alter parent elements.