### PR TITLE
[IPAD-379] Fix Plotly error handling

### DIFF
--- a/src/services/omicNavigator.service.js
+++ b/src/services/omicNavigator.service.js
@@ -85,25 +85,25 @@ class OmicNavigatorService {
   ) {
     const paramsObj = params ? { digits: 10 } : {};
     const self = this;
-    return new Promise(function(resolve, reject) {
-      const axiosPostUrl = `${self.url}/${method}/json?auto_unbox=true`;
-      axios
-        .post(axiosPostUrl, obj, {
-          params: paramsObj,
-          responseType: 'text',
-          cancelToken,
-          timeout,
-        })
-        .then(response => resolve(response.data))
-        .catch(function(error) {
-          if (!axios.isCancel(error)) {
-            toast.error(`${error.message}`);
-            if (handleError != null) {
-              handleError(false);
-            }
-          }
-        });
-    });
+    const axiosPostUrl = `${self.url}/${method}/json?auto_unbox=true`;
+    try {
+      const { data } = await axios.post(axiosPostUrl, obj, {
+        params: paramsObj,
+        responseType: 'text',
+        cancelToken,
+        timeout,
+      });
+      return data;
+    } catch (error) {
+      if (!axios.isCancel(error)) {
+        toast.error(`${error.message}`);
+        if (handleError != null) {
+          handleError(false);
+        } else {
+          throw error;
+        }
+      }
+    }
   }
 
   async ocpuPlotCall(method, obj, handleError, cancelToken, timeout) {


### PR DESCRIPTION
Adjusts service so that when one plot fails, the rest that succeed still populate.  You can test this by selecting feature ids "624245" and "22409" in the following study: "RNAseq123", model: "Differential_Expression", test: "BasalvsLP".  In .184 or .173 this will result in just 1 of 5 plots showing up, while with this fix, 4 of 5 plots will display. 

Dev note: Promise.allSettled wasn't waiting for all promises to be fulfilled/rejected because plots vs. plotly plots were being handled differently in the service.  I adjusted to use plotly to use try/catch and throw an error, which resolved the issue.

![4 plots](https://user-images.githubusercontent.com/10191004/156451804-5e388127-ea26-47b6-9c3d-f9ebb0a7d466.png)