### PR TITLE
[AU-384] Scatterplot - ignore click when options open

### DIFF
--- a/src/components/Differential/ScatterPlot.jsx
+++ b/src/components/Differential/ScatterPlot.jsx
@@ -1719,6 +1719,7 @@ class ScatterPlot extends React.PureComponent {
     //   resizeScalarY: 1,
     //   volcanoCircleText: [],
     // });
+    if (this.state.optionsOpen) return;
     this.props.onResetDifferentialOutlinedFeature();
     this.props.onHandleHighlightedFeaturesDifferential([], false);
   }
@@ -1921,7 +1922,11 @@ class ScatterPlot extends React.PureComponent {
 
   toggleOptionsPopup = (e, obj, close) => {
     if (close) {
-      this.setState({ optionsOpen: false });
+      const self = this;
+      // timeout needed so optionsOpen still true briefly on scatterplot click
+      setTimeout(function() {
+        self.setState({ optionsOpen: false });
+      }, 10);
     } else {
       this.setState({ optionsOpen: true });
     }


### PR DESCRIPTION
Problem: When closing the scatterplot options popup, a click on the scatter plot itself inadvertently clears the multi-feature selection.
Solution: Add a flag to scatterplot click handling to ensure that the options popup is closed. If it is open, just return. Note, to support the flag, a slight timeout needed to be added when toggling options closed.
To test: Multi-select features. Click an empty part of the scatter plot and they should de-select. Do the same thing after opening the options popup. The features should remains selected.