### PR TITLE
[IPAD-388] Add table support for columns wo/data

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 AbbVie Inc.
+Copyright (c) 2022 AbbVie Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -1286,22 +1286,41 @@ class Differential extends Component {
     function isNotNANorNullNorUndefined(o) {
       return typeof o !== 'undefined' && o !== null && o !== 'NA';
     }
-    function everyIsNotNANorNullNorUndefined(arr) {
-      return arr.every(isNotNANorNullNorUndefined);
-    }
-    const objectValuesArr = [...differentialResultsVar].map(f =>
-      Object.values(f),
-    );
-    const firstFullObjectIndex = objectValuesArr.findIndex(
-      everyIsNotNANorNullNorUndefined,
-    );
-    const firstFullObject = differentialResultsVar[firstFullObjectIndex];
-    for (let [key, value] of Object.entries(firstFullObject)) {
-      if (typeof value === 'string' || value instanceof String) {
-        differentialAlphanumericFields.push(key);
-      } else {
-        differentialNumericFields.push(key);
-      }
+
+    if (differentialResultsVar.length < 1) return;
+    // grab first object
+    const firstFullObject =
+      differentialResultsVar.length > 0 ? [...differentialResultsVar][0] : null;
+    // if exists, loop through the values of each property,
+    // find the first real value,
+    // and set the config column types
+    if (firstFullObject) {
+      let allProperties = Object.keys(firstFullObject);
+      const dataCopy = [...differentialResultsVar];
+      allProperties.forEach(property => {
+        // loop through data, one property at a time
+        const notNullObject = dataCopy.find(row => {
+          // find the first value for that property
+          return isNotNANorNullNorUndefined(row[property]);
+        });
+        let notNullValue = null;
+        if (notNullObject) {
+          notNullValue = notNullObject[property] || null;
+          // if the property has a value somewhere in the data
+          if (
+            typeof notNullValue === 'string' ||
+            notNullValue instanceof String
+          ) {
+            // push it to the appropriate field type
+            differentialAlphanumericFields.push(property);
+          } else {
+            differentialNumericFields.push(property);
+          }
+        } else {
+          // otherwise push it to type string
+          differentialAlphanumericFields.push(property);
+        }
+      });
     }
     const alphanumericTrigger = differentialAlphanumericFields[0];
     if (differentialFeature !== '') {

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -172,25 +172,22 @@ class DifferentialDetail extends Component {
         this.props.onResetDifferentialOutlinedFeature();
         this.pageToFeature();
       }
+      let sortedData =
+        this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.getSortedData() ||
+        this.props.differentialResults;
+      // const sortDataIds = [...sortedData].map(d => d[this.props.differentialFeatureIdKey]);
+      const volcanoPlotDataArrIds = [...volcanoPlotSelectedDataArr].map(
+        d => d[this.props.differentialFeatureIdKey],
+      );
+      const matchCurrentTableOrder = [...sortedData].filter(d =>
+        volcanoPlotDataArrIds.includes(d[this.props.differentialFeatureIdKey]),
+      );
+      this.setState({
+        differentialTableData: matchCurrentTableOrder,
+        volcanoPlotRows: volcanoPlotSelectedDataArr.length,
+      });
       if (this.props.plotMultiFeatureAvailable) {
         // IF MULTI-FEATURE PLOTTING AVAILABLE AND THERE IS DATA
-        let sortedData =
-          this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.getSortedData() ||
-          this.props.differentialResults;
-        // const sortDataIds = [...sortedData].map(d => d[this.props.differentialFeatureIdKey]);
-        const volcanoPlotDataArrIds = [...volcanoPlotSelectedDataArr].map(
-          d => d[this.props.differentialFeatureIdKey],
-        );
-        const matchCurrentTableOrder = [...sortedData].filter(d =>
-          volcanoPlotDataArrIds.includes(
-            d[this.props.differentialFeatureIdKey],
-          ),
-        );
-        const self = this;
-        this.setState({
-          differentialTableData: matchCurrentTableOrder,
-          volcanoPlotRows: volcanoPlotSelectedDataArr.length,
-        });
         let multiselectedFeaturesArrRemaining = [
           ...volcanoPlotSelectedDataArr,
         ].filter(item =>

--- a/src/components/Differential/MetafeaturesTable.jsx
+++ b/src/components/Differential/MetafeaturesTable.jsx
@@ -72,21 +72,41 @@ class MetafeaturesTable extends Component {
       function isNotNANorNullNorUndefined(o) {
         return typeof o !== 'undefined' && o !== null && o !== 'NA';
       }
-      function everyIsNotNANorNullNorUndefined(arr) {
-        return arr.every(isNotNANorNullNorUndefined);
+      if (data.length < 1) return;
+      // grab first object
+      const firstFullObject = data.length > 0 ? [...data][0] : null;
+      // if exists, loop through the values of each property,
+      // find the first real value,
+      // and set the config column types
+      if (firstFullObject) {
+        let allProperties = Object.keys(firstFullObject);
+        const dataCopy = [...data];
+        allProperties.forEach(property => {
+          // loop through data, one property at a time
+          const notNullObject = dataCopy.find(row => {
+            // find the first value for that property
+            return isNotNANorNullNorUndefined(row[property]);
+          });
+          let notNullValue = null;
+          if (notNullObject) {
+            notNullValue = notNullObject[property] || null;
+            // if the property has a value somewhere in the data
+            if (
+              typeof notNullValue === 'string' ||
+              notNullValue instanceof String
+            ) {
+              // push it to the appropriate field type
+              metafeaturesAlphanumericFields.push(property);
+            } else {
+              metafeaturesNumericFields.push(property);
+            }
+          } else {
+            // otherwise push it to type string
+            metafeaturesAlphanumericFields.push(property);
+          }
+        });
       }
-      const objectValuesArr = [...data].map(f => Object.values(f));
-      const firstFullObjectIndex = objectValuesArr.findIndex(
-        everyIsNotNANorNullNorUndefined,
-      );
-      const firstFullObject = data[firstFullObjectIndex];
-      for (let [key, value] of Object.entries(firstFullObject)) {
-        if (typeof value === 'string' || value instanceof String) {
-          metafeaturesAlphanumericFields.push(key);
-        } else {
-          metafeaturesNumericFields.push(key);
-        }
-      }
+
       const metafeaturesAlphanumericColumnsMapped = metafeaturesAlphanumericFields.map(
         f => {
           return {

--- a/src/components/Differential/MetafeaturesTableDynamic.jsx
+++ b/src/components/Differential/MetafeaturesTableDynamic.jsx
@@ -93,20 +93,39 @@ class MetafeaturesTableDynamic extends Component {
       function isNotNANorNullNorUndefined(o) {
         return typeof o !== 'undefined' && o !== null && o !== 'NA';
       }
-      function everyIsNotNANorNullNorUndefined(arr) {
-        return arr.every(isNotNANorNullNorUndefined);
-      }
-      const objectValuesArr = [...data].map(f => Object.values(f));
-      const firstFullObjectIndex = objectValuesArr.findIndex(
-        everyIsNotNANorNullNorUndefined,
-      );
-      const firstFullObject = data[firstFullObjectIndex];
-      for (let [key, value] of Object.entries(firstFullObject)) {
-        if (typeof value === 'string' || value instanceof String) {
-          metafeaturesAlphanumericFields.push(key);
-        } else {
-          metafeaturesNumericFields.push(key);
-        }
+      if (data.length < 1) return;
+      // grab first object
+      const firstFullObject = data.length > 0 ? [...data][0] : null;
+      // if exists, loop through the values of each property,
+      // find the first real value,
+      // and set the config column types
+      if (firstFullObject) {
+        let allProperties = Object.keys(firstFullObject);
+        const dataCopy = [...data];
+        allProperties.forEach(property => {
+          // loop through data, one property at a time
+          const notNullObject = dataCopy.find(row => {
+            // find the first value for that property
+            return isNotNANorNullNorUndefined(row[property]);
+          });
+          let notNullValue = null;
+          if (notNullObject) {
+            notNullValue = notNullObject[property] || null;
+            // if the property has a value somewhere in the data
+            if (
+              typeof notNullValue === 'string' ||
+              notNullValue instanceof String
+            ) {
+              // push it to the appropriate field type
+              metafeaturesAlphanumericFields.push(property);
+            } else {
+              metafeaturesNumericFields.push(property);
+            }
+          } else {
+            // otherwise push it to type string
+            metafeaturesAlphanumericFields.push(property);
+          }
+        });
       }
       const metafeaturesAlphanumericColumnsMapped = metafeaturesAlphanumericFields.map(
         f => {

--- a/src/components/Differential/ScatterPlot.jsx
+++ b/src/components/Differential/ScatterPlot.jsx
@@ -1807,117 +1807,130 @@ class ScatterPlot extends React.PureComponent {
   };
 
   getAxisLabels = () => {
-    if (this.props.differentialResults.length > 0) {
-      let differentialAlphanumericFields = [];
-      let relevantConfigColumns = [];
-      function isNotNANorNullNorUndefined(o) {
-        return typeof o !== 'undefined' && o !== null && o !== 'NA';
-      }
-      function everyIsNotNANorNullNorUndefined(arr) {
-        return arr.every(isNotNANorNullNorUndefined);
-      }
-      const objectValuesArr = [...this.props.differentialResults].map(f =>
-        Object.values(f),
-      );
-      const firstFullObjectIndex = objectValuesArr.findIndex(
-        everyIsNotNANorNullNorUndefined,
-      );
-      const firstFullObject = this.props.differentialResults[
-        firstFullObjectIndex
-      ];
-      for (let [key, value] of Object.entries(firstFullObject)) {
-        if (typeof value === 'string' || value instanceof String) {
-          differentialAlphanumericFields.push(key);
+    const { differentialResults } = this.props;
+    if (differentialResults.length < 1) return;
+    let differentialAlphanumericFields = [];
+    let relevantConfigColumns = [];
+    function isNotNANorNullNorUndefined(o) {
+      return typeof o !== 'undefined' && o !== null && o !== 'NA';
+    }
+    // grab first object
+    const firstFullObject =
+      differentialResults.length > 0 ? [...differentialResults][0] : null;
+    // if exists, loop through the values of each property,
+    // find the first real value,
+    // and set the config column types
+    if (firstFullObject) {
+      let allProperties = Object.keys(firstFullObject);
+      const dataCopy = [...differentialResults];
+      allProperties.forEach(property => {
+        // loop through data, one property at a time
+        const notNullObject = dataCopy.find(row => {
+          // find the first value for that property
+          return isNotNANorNullNorUndefined(row[property]);
+        });
+        let notNullValue = null;
+        if (notNullObject) {
+          notNullValue = notNullObject[property] || null;
+          // if the property has a value somewhere in the data
+          if (
+            typeof notNullValue === 'string' ||
+            notNullValue instanceof String
+          ) {
+            // push it to the appropriate field type
+            differentialAlphanumericFields.push(property);
+          } else {
+            relevantConfigColumns.push(property);
+          }
         } else {
-          relevantConfigColumns.push(key);
+          // otherwise push it to type string
+          differentialAlphanumericFields.push(property);
         }
-      }
-      //Pushes "none" option into Volcano circle text dropdown
-      differentialAlphanumericFields.unshift('None');
-      let volcanoCircleLabelsVar = differentialAlphanumericFields.map(e => {
-        return {
-          key: e,
-          text: e,
-          value: e,
-        };
-      });
-
-      let storedVolcanoCircleLabel = sessionStorage.getItem(
-        'volcanoCircleLabel',
-      );
-      let nextVolcanoCircleLabel = differentialAlphanumericFields?.includes(
-        storedVolcanoCircleLabel,
-      )
-        ? storedVolcanoCircleLabel
-        : this.props.differentialFeatureIdKey;
-      this.setState({
-        volcanoCircleLabels: volcanoCircleLabelsVar,
-        volcanoCircleLabel: nextVolcanoCircleLabel,
-      });
-      sessionStorage.setItem('volcanoCircleLabel', nextVolcanoCircleLabel);
-      // XAXIS
-      let storedXAxisLabel = sessionStorage.getItem('xAxisLabel');
-      // if session storage cached xlabel is an option, use it
-      let xLabel = relevantConfigColumns?.includes(storedXAxisLabel)
-        ? storedXAxisLabel
-        : null;
-
-      // otherwise, if not cached in session, default to logFC. If no logFC, set to first index
-      if (xLabel == null) {
-        if (relevantConfigColumns.indexOf('logFC') >= 0) {
-          xLabel = 'logFC';
-        } else {
-          xLabel = relevantConfigColumns[0];
-        }
-      }
-      // YAXIS
-      let storedYAxisLabel = sessionStorage.getItem('yAxisLabel');
-      // if session storage cached ylabel is an option, use it, otherwise, if not cached in session, look for a p value label
-      let yLabel = relevantConfigColumns?.includes(storedYAxisLabel)
-        ? storedYAxisLabel
-        : null;
-      // DOY
-      let doY = this.state.doYAxisTransformation;
-      if (yLabel == null) {
-        if (relevantConfigColumns.indexOf('P_Value') >= 0) {
-          yLabel = 'P_Value';
-          doY = true;
-        } else if (relevantConfigColumns.indexOf('P.Value') >= 0) {
-          yLabel = 'P.Value';
-          doY = true;
-        } else if (relevantConfigColumns.indexOf('PValue') >= 0) {
-          yLabel = 'PValue';
-          doY = true;
-        } else if (relevantConfigColumns.indexOf('PVal') >= 0) {
-          yLabel = 'PVal';
-          doY = true;
-        } else if (relevantConfigColumns.indexOf('P value') >= 0) {
-          yLabel = 'P value';
-          doY = true;
-        } else if (relevantConfigColumns.indexOf('adj_P_Val') >= 0) {
-          yLabel = 'adj_P_Val';
-          doY = true;
-        } else if (relevantConfigColumns.indexOf('adj.P.Val') >= 0) {
-          yLabel = 'adj.P.Val';
-          doY = true;
-        } else {
-          yLabel = relevantConfigColumns[0];
-        }
-      }
-      const axes = relevantConfigColumns.map(e => {
-        return {
-          key: e,
-          text: e,
-          value: e,
-        };
-      });
-      this.setState({
-        axisLabels: axes,
-        yAxisLabel: yLabel,
-        doYAxisTransformation: doY,
-        xAxisLabel: xLabel,
       });
     }
+    //Pushes "none" option into Volcano circle text dropdown
+    differentialAlphanumericFields.unshift('None');
+    let volcanoCircleLabelsVar = differentialAlphanumericFields.map(e => {
+      return {
+        key: e,
+        text: e,
+        value: e,
+      };
+    });
+
+    let storedVolcanoCircleLabel = sessionStorage.getItem('volcanoCircleLabel');
+    let nextVolcanoCircleLabel = differentialAlphanumericFields?.includes(
+      storedVolcanoCircleLabel,
+    )
+      ? storedVolcanoCircleLabel
+      : this.props.differentialFeatureIdKey;
+    this.setState({
+      volcanoCircleLabels: volcanoCircleLabelsVar,
+      volcanoCircleLabel: nextVolcanoCircleLabel,
+    });
+    sessionStorage.setItem('volcanoCircleLabel', nextVolcanoCircleLabel);
+    // XAXIS
+    let storedXAxisLabel = sessionStorage.getItem('xAxisLabel');
+    // if session storage cached xlabel is an option, use it
+    let xLabel = relevantConfigColumns?.includes(storedXAxisLabel)
+      ? storedXAxisLabel
+      : null;
+
+    // otherwise, if not cached in session, default to logFC. If no logFC, set to first index
+    if (xLabel == null) {
+      if (relevantConfigColumns.indexOf('logFC') >= 0) {
+        xLabel = 'logFC';
+      } else {
+        xLabel = relevantConfigColumns[0];
+      }
+    }
+    // YAXIS
+    let storedYAxisLabel = sessionStorage.getItem('yAxisLabel');
+    // if session storage cached ylabel is an option, use it, otherwise, if not cached in session, look for a p value label
+    let yLabel = relevantConfigColumns?.includes(storedYAxisLabel)
+      ? storedYAxisLabel
+      : null;
+    // DOY
+    let doY = this.state.doYAxisTransformation;
+    if (yLabel == null) {
+      if (relevantConfigColumns.indexOf('P_Value') >= 0) {
+        yLabel = 'P_Value';
+        doY = true;
+      } else if (relevantConfigColumns.indexOf('P.Value') >= 0) {
+        yLabel = 'P.Value';
+        doY = true;
+      } else if (relevantConfigColumns.indexOf('PValue') >= 0) {
+        yLabel = 'PValue';
+        doY = true;
+      } else if (relevantConfigColumns.indexOf('PVal') >= 0) {
+        yLabel = 'PVal';
+        doY = true;
+      } else if (relevantConfigColumns.indexOf('P value') >= 0) {
+        yLabel = 'P value';
+        doY = true;
+      } else if (relevantConfigColumns.indexOf('adj_P_Val') >= 0) {
+        yLabel = 'adj_P_Val';
+        doY = true;
+      } else if (relevantConfigColumns.indexOf('adj.P.Val') >= 0) {
+        yLabel = 'adj.P.Val';
+        doY = true;
+      } else {
+        yLabel = relevantConfigColumns[0];
+      }
+    }
+    const axes = relevantConfigColumns.map(e => {
+      return {
+        key: e,
+        text: e,
+        value: e,
+      };
+    });
+    this.setState({
+      axisLabels: axes,
+      yAxisLabel: yLabel,
+      doYAxisTransformation: doY,
+      xAxisLabel: xLabel,
+    });
   };
 
   toggleOptionsPopup = (e, obj, close) => {

--- a/src/components/Enrichment/FilteredDifferentialTable.jsx
+++ b/src/components/Enrichment/FilteredDifferentialTable.jsx
@@ -171,20 +171,40 @@ class FilteredDifferentialTable extends Component {
     function isNotNANorNullNorUndefined(o) {
       return typeof o !== 'undefined' && o !== null && o !== 'NA';
     }
-    function everyIsNotNANorNullNorUndefined(arr) {
-      return arr.every(isNotNANorNullNorUndefined);
-    }
-    const objectValuesArr = [...dataFromService].map(f => Object.values(f));
-    const firstFullObjectIndex = objectValuesArr.findIndex(
-      everyIsNotNANorNullNorUndefined,
-    );
-    const firstFullObject = dataFromService[firstFullObjectIndex];
-    for (let [key, value] of Object.entries(firstFullObject)) {
-      if (typeof value === 'string' || value instanceof String) {
-        filteredDifferentialAlphanumericFields.push(key);
-      } else {
-        filteredDifferentialNumericFields.push(key);
-      }
+    if (dataFromService.length < 1) return;
+    // grab first object
+    const firstFullObject =
+      dataFromService.length > 0 ? [...dataFromService][0] : null;
+    // if exists, loop through the values of each property,
+    // find the first real value,
+    // and set the config column types
+    if (firstFullObject) {
+      let allProperties = Object.keys(firstFullObject);
+      const dataCopy = [...dataFromService];
+      allProperties.forEach(property => {
+        // loop through data, one property at a time
+        const notNullObject = dataCopy.find(row => {
+          // find the first value for that property
+          return isNotNANorNullNorUndefined(row[property]);
+        });
+        let notNullValue = null;
+        if (notNullObject) {
+          notNullValue = notNullObject[property] || null;
+          // if the property has a value somewhere in the data
+          if (
+            typeof notNullValue === 'string' ||
+            notNullValue instanceof String
+          ) {
+            // push it to the appropriate field type
+            filteredDifferentialAlphanumericFields.push(property);
+          } else {
+            filteredDifferentialNumericFields.push(property);
+          }
+        } else {
+          // otherwise push it to type string
+          filteredDifferentialAlphanumericFields.push(property);
+        }
+      });
     }
     const alphanumericTrigger = filteredDifferentialAlphanumericFields[0];
     this.props.onHandleDifferentialFeatureIdKey(


### PR DESCRIPTION
Adjusts table filter calculation (5 tables) to loop through each column (property) until it finds a real value.  Prior, we were looking for a row with data for all properties, and some studies (e.g. D04042022...) didn't fit that model.  This solution is more flexible and fast.  If a column has no real data at all, the column filter type will default to string.