### PR TITLE
[IPAD-386] - Plotly axis cutoff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "dependencies": {
         "d3-hexbin": "^0.2.2",
         "gh-pages": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "private": true,
   "dependencies": {
     "d3-hexbin": "^0.2.2",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Differential/PlotlyMultiFeature.jsx
+++ b/src/components/Differential/PlotlyMultiFeature.jsx
@@ -38,12 +38,12 @@ export default class PlotlyMultiFeature extends Component {
   }
 
   getJson = () => {
-    const { plotlyData, width, height } = this.props;
+    const { plotlyData, width, height, plotId } = this.props;
     const parsedData = JSON.parse(plotlyData);
     const data = parsedData?.data || null;
     let layout = parsedData?.layout || null;
     if (layout) {
-      layout = reviseLayout(layout, width, height);
+      layout = reviseLayout(layout, width, height, plotId);
     }
     this.setState({
       json: {

--- a/src/components/Differential/PlotlyOverlay.jsx
+++ b/src/components/Differential/PlotlyOverlay.jsx
@@ -29,12 +29,12 @@ export default class PlotlyOverlay extends Component {
   }
 
   getJson = () => {
-    const { plotlyData, width, height } = this.props;
+    const { plotlyData, width, height, plotId } = this.props;
     const parsedData = JSON.parse(plotlyData);
     const data = parsedData?.data || null;
     let layout = parsedData?.layout || null;
     if (layout) {
-      layout = reviseLayout(layout, width, height);
+      layout = reviseLayout(layout, width, height, plotId);
     }
     this.setState({
       json: {

--- a/src/components/Differential/TabMultiFeature.jsx
+++ b/src/components/Differential/TabMultiFeature.jsx
@@ -81,6 +81,7 @@ class TabMultiFeature extends Component {
                       height={divHeightPadding}
                       width={divWidthPadding}
                       plotName={s.plotType.plotDisplay}
+                      plotId={s.plotType.plotID}
                       plotlyExport={this.props.plotlyExport}
                       plotlyExportType={this.props.plotlyExportType}
                       parentNode={

--- a/src/components/Differential/TabOverlay.jsx
+++ b/src/components/Differential/TabOverlay.jsx
@@ -106,6 +106,7 @@ class TabOverlay extends Component {
                       height={svgContainerHeight}
                       width={svgContainerWidth}
                       plotName={s.plotType.plotDisplay}
+                      plotId={s.plotType.plotID}
                       plotlyExport={this.props.plotlyExport}
                       plotlyExportType={this.props.plotlyExportType}
                       parentNode={this.props.differentialPlotsOverlayRefFwd}

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -436,7 +436,6 @@ export const clickDownload = _.debounce(parentNode => {
 export const reviseLayout = (layout, width, height, plotId) => {
   let layoutParsed = layout;
   if (plotId && plotId.includes('heatmaply')) {
-    debugger;
     const layoutString = JSON.stringify(layout);
     const layoutStringReplaced = layoutString.replaceAll(
       '"automargin":true',

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -433,13 +433,23 @@ export const clickDownload = _.debounce(parentNode => {
   }
 }, 1000);
 
-export const reviseLayout = (layout, width, height) => {
-  const layoutString = JSON.stringify(layout);
-  const layoutStringReplaced = layoutString.replaceAll(
-    '"automargin":true',
-    '"automargin":false',
-  );
-  const layoutParsed = JSON.parse(layoutStringReplaced);
+export const reviseLayout = (layout, width, height, plotId) => {
+  let layoutParsed = layout;
+  if (plotId && plotId.includes('heatmaply')) {
+    debugger;
+    const layoutString = JSON.stringify(layout);
+    const layoutStringReplaced = layoutString.replaceAll(
+      '"automargin":true',
+      '"automargin":false',
+    );
+    layoutParsed = JSON.parse(layoutStringReplaced);
+    layoutParsed.margin = {
+      b: layoutParsed.margin.b,
+      l: layoutParsed.margin.l + 50,
+      r: layoutParsed.margin.r,
+      t: layoutParsed.margin.t,
+    };
+  }
   layoutParsed.width = Math.floor(width * 0.9);
   layoutParsed.height = Math.floor(height * 0.9);
   return layoutParsed;

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.6.3',
+      appVersion: '1.6.4',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
Fixes Plotly plots with longer x-axis names that were getting cut off on full-screen and when exported.  Long labels were cutoff because we removed "auto-margins" that were "squishing" the entire plot in some instances (a known Plotly bug). Only "heatmaply" plot types show to be affected by the auto-margin issue, so for now, this PR adjusts the flag so all other plot types get auto-margins, and "heatmaply" just gets an additional hard-coded right margin of 50.

To test: first go to prod: /differential/RNAseq123/Differential_Expression/BasalvsLP
Under the symbol filters, click the top two results "0610009B22Rik".  Multi-select them. Click the "Full Screen" button. Notice on the "Expression Heatmap interactive with plotly" plot has labels cutoff in the view and export. Now go to this branch, and repeat. All should display/export fine.