### PR TITLE
[IPAD-400] Optimizes column configuration - Differential/Enrichment

### DIFF
--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -1435,6 +1435,12 @@ class Differential extends Component {
         };
       },
     );
+    const multisetColsDifferentialVar = this.listToJson(
+      differentialNumericFields,
+    );
+    this.setState({
+      multisetColsDifferential: multisetColsDifferentialVar,
+    });
     const differentialNumericColumnsMapped = differentialNumericFields.map(
       c => {
         return {
@@ -1495,12 +1501,6 @@ class Differential extends Component {
     const configCols = checkboxAndAlphanumericCols.concat(
       differentialNumericColumnsMapped,
     );
-    const multisetColsDifferentialVar = this.listToJson(
-      differentialNumericFields,
-    );
-    this.setState({
-      multisetColsDifferential: multisetColsDifferentialVar,
-    });
     return configCols;
   };
 

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -40,6 +40,7 @@ class Differential extends Component {
     this.state = {
       // GENERAL
       // differentialPlotTypes: [],
+
       differentialStudyMetadata: [],
       differentialModelsAndTests: [],
       differentialTestsMetadata: [],
@@ -54,7 +55,8 @@ class Differential extends Component {
       /**
        * @type {QHGrid.ColumnConfig[]}
        */
-      // differentialColumns: [],
+      differentialColumns: [],
+      differentialColumnsConfigured: false,
       isSearchingDifferential: false,
       isValidSearchDifferential: false,
       isFilteredDifferential: false,
@@ -143,6 +145,12 @@ class Differential extends Component {
     });
   };
 
+  handleDifferentialColumnsConfigured = bool => {
+    this.setState({
+      differentialColumnsConfigured: bool,
+    });
+  };
+
   handleSearchTransitionDifferentialAlt = bool => {
     this.setState({
       differentialResultsTableLoading: bool,
@@ -181,14 +189,19 @@ class Differential extends Component {
     /**
      * @type {QHGrid.ColumnConfig<{}>[]}
      */
-    let columns = [{}];
     // need this check for page refresh
-    if (searchResults.differentialResults?.length > 0) {
-      columns = this.getConfigCols(searchResults);
+    if (
+      searchResults?.differentialResults?.length &&
+      !this.state.differentialColumnsConfigured
+    ) {
+      let columns = this.getConfigCols(searchResults);
+      this.setState({
+        differentialColumnsConfigured: true,
+        differentialColumns: columns,
+      });
     }
     this.setState({
       differentialResults: searchResults.differentialResults,
-      differentialColumns: columns,
       isSearchingDifferential: false,
       isValidSearchDifferential: true,
       differentialResultsTableLoading: false,
@@ -1283,8 +1296,6 @@ class Differential extends Component {
     function isNotNANorNullNorUndefined(o) {
       return typeof o !== 'undefined' && o !== null && o !== 'NA';
     }
-
-    if (differentialResultsVar.length < 1) return;
     // grab first object
     const firstFullObject =
       differentialResultsVar.length > 0 ? [...differentialResultsVar][0] : null;
@@ -1424,12 +1435,6 @@ class Differential extends Component {
         };
       },
     );
-    const multisetColsDifferentialVar = this.listToJson(
-      differentialNumericFields,
-    );
-    this.setState({
-      multisetColsDifferential: multisetColsDifferentialVar,
-    });
     const differentialNumericColumnsMapped = differentialNumericFields.map(
       c => {
         return {
@@ -1490,6 +1495,12 @@ class Differential extends Component {
     const configCols = checkboxAndAlphanumericCols.concat(
       differentialNumericColumnsMapped,
     );
+    const multisetColsDifferentialVar = this.listToJson(
+      differentialNumericFields,
+    );
+    this.setState({
+      multisetColsDifferential: multisetColsDifferentialVar,
+    });
     return configCols;
   };
 
@@ -1539,7 +1550,7 @@ class Differential extends Component {
           onBackToTable={this.backToTable}
           onHandleUpdateDifferentialResults={this.updateDifferentialResults}
           onHandleVolcanoState={this.updateVolcanoState}
-          onHandleTableDataChange={this.handleTableDataChange}
+          onTableDataChange={this.handleTableDataChange}
           fwdRefDVC={this.differentialViewContainerRef}
           onHandleMultifeaturePlot={this.handleMultifeaturePlot}
           onGetMultifeaturePlotTransition={this.getMultifeaturePlotTransition}
@@ -1692,6 +1703,9 @@ class Differential extends Component {
                 this.handleMultisetFiltersVisibleParentRef
               }
               onHandleIsFilteredDifferential={this.handleIsFilteredDifferential}
+              onHandleDifferentialColumnsConfigured={
+                this.handleDifferentialColumnsConfigured
+              }
             />
           </Grid.Column>
           <Grid.Column

--- a/src/components/Differential/DifferentialSearch.jsx
+++ b/src/components/Differential/DifferentialSearch.jsx
@@ -408,7 +408,9 @@ class DifferentialSearch extends Component {
       onMultisetQueriedDifferential,
       onSearchChangeDifferential,
       onSearchTransitionDifferential,
+      onHandleDifferentialColumnsConfigured,
     } = this.props;
+    onHandleDifferentialColumnsConfigured(false);
     onSearchTransitionDifferential(true);
     onMultisetQueriedDifferential(false);
     const differentialTestMeta = this.props.differentialTestsMetadata.find(

--- a/src/components/Differential/MetafeaturesTable.jsx
+++ b/src/components/Differential/MetafeaturesTable.jsx
@@ -12,7 +12,6 @@ class MetafeaturesTable extends Component {
   state = {
     metafeaturesTableConfigCols: [],
     metafeaturesTableData: [],
-    filteredBarcodeData: [],
     itemsPerPageMetafeaturesTable:
       parseInt(localStorage.getItem('itemsPerPageMetafeaturesTable'), 10) || 60,
     additionalTemplateInfo: [],

--- a/src/components/Differential/MetafeaturesTableDynamic.jsx
+++ b/src/components/Differential/MetafeaturesTableDynamic.jsx
@@ -12,7 +12,6 @@ class MetafeaturesTableDynamic extends Component {
   state = {
     metafeaturesTableConfigCols: [],
     metafeaturesTableData: [],
-    filteredBarcodeData: [],
     itemsPerPageMetafeaturesTable:
       parseInt(localStorage.getItem('itemsPerPageMetafeaturesTable'), 10) || 60,
     additionalTemplateInfo: [],

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -46,6 +46,8 @@ class Enrichment extends Component {
     isEnrichmentTableLoading: false,
     enrichmentResults: [],
     enrichmentColumns: [],
+    enrichmentColumnsUnfiltered: [],
+    enrichmentColumnsConfigured: false,
     enrichmentFeatureID: '',
     enrichmentPlotSVGHeight: 0,
     enrichmentPlotSVGWidth: 0,
@@ -259,6 +261,12 @@ class Enrichment extends Component {
     sessionStorage.setItem('pValueType', type);
   };
 
+  handleEnrichmentColumnsConfigured = bool => {
+    this.setState({
+      enrichmentColumnsConfigured: bool,
+    });
+  };
+
   getThreePlotsFromUrl = (
     enrichmentStudy,
     enrichmentModel,
@@ -438,11 +446,15 @@ class Enrichment extends Component {
     // if (this.state.enrichmentColumns.length === 0) {
     //   this.handleColumnReorder(searchResults);
     // }
-    let columns = [];
-    if (searchResults?.length > 0) {
+    let columns = this.state.enrichmentColumnsUnfiltered || [];
+    if (searchResults?.length && !this.state.enrichmentColumnsConfigured) {
       columns = this.getConfigCols(searchResults);
+      this.setState({
+        enrichmentColumnsConfigured: true,
+        enrichmentColumnsUnfiltered: columns,
+      });
+      console.log('enrichment config cols - see this just one per db');
     }
-    this.setState({ enrichmentColumnsUnfiltered: columns });
     if (multisetTestsFilteredOut.length > 0) {
       columns = columns.map(col => {
         if (!multisetTestsFilteredOut.includes(col.title)) {
@@ -620,11 +632,20 @@ class Enrichment extends Component {
                 enrichmentsFavicons: favicons,
               },
               function() {
-                let columns = [];
-                if (this.state.enrichmentResults?.length > 0) {
+                let columns = this.state.enrichmentColumnsUnfiltered || [];
+                if (
+                  this.state.enrichmentResults?.length &&
+                  !this.state.enrichmentColumnsConfigured
+                ) {
                   columns = this.getConfigCols(this.state.enrichmentResults);
+                  this.setState({
+                    enrichmentColumnsConfigured: true,
+                    enrichmentColumnsUnfiltered: columns,
+                  });
+                  console.log(
+                    'enrichment config cols - see this just one per db',
+                  );
                 }
-                this.setState({ enrichmentColumnsUnfiltered: columns });
                 if (this.state.multisetTestsFilteredOut.length > 0) {
                   const self = this;
                   columns = columns.filter(function(col) {
@@ -670,11 +691,20 @@ class Enrichment extends Component {
                   enrichmentsFavicons: favicons,
                 },
                 function() {
-                  let columns = [];
-                  if (self.state.enrichmentResults?.length > 0) {
-                    columns = self.getConfigCols(self.state.enrichmentResults);
+                  let columns = this.state.enrichmentColumnsUnfiltered || [];
+                  if (
+                    this.state.enrichmentResults?.length &&
+                    !this.state.enrichmentColumnsConfigured
+                  ) {
+                    columns = this.getConfigCols(this.state.enrichmentResults);
+                    this.setState({
+                      enrichmentColumnsConfigured: true,
+                      enrichmentColumnsUnfiltered: columns,
+                    });
+                    console.log(
+                      'enrichment config cols - see this just one per db',
+                    );
                   }
-                  self.setState({ enrichmentColumnsUnfiltered: columns });
                   if (self.state.multisetTestsFilteredOut.length > 0) {
                     columns = columns.filter(function(col) {
                       return !self.setState.MultisetTestsFilteredOut.includes(
@@ -837,7 +867,6 @@ class Enrichment extends Component {
     function isNotNANorNullNorUndefined(o) {
       return typeof o !== 'undefined' && o !== null && o !== 'NA';
     }
-    if (annotationData.length < 1) return;
     // grab first object
     let firstFullObject =
       [...annotationData].length > 0 ? [...annotationData][0] : null;
@@ -2494,6 +2523,9 @@ class Enrichment extends Component {
                 this.handleIsDataStreamingEnrichmentsTable
               }
               onHandlePValueTypeChange={this.handlePValueTypeChange}
+              onHandleEnrichmentColumnsConfigured={
+                this.handleEnrichmentColumnsConfigured
+              }
             />
           </Grid.Column>
           <Grid.Column

--- a/src/components/Enrichment/EnrichmentSearch.jsx
+++ b/src/components/Enrichment/EnrichmentSearch.jsx
@@ -403,7 +403,9 @@ class EnrichmentSearch extends Component {
       onMultisetQueriedEnrichment,
       onSearchTransitionEnrichment,
       onSearchChangeEnrichment,
+      onHandleEnrichmentColumnsConfigured,
     } = this.props;
+    onHandleEnrichmentColumnsConfigured(false);
     onSearchTransitionEnrichment(true);
     onMultisetQueriedEnrichment(false);
     const enrichmentAnnotationMeta = this.props.enrichmentAnnotationsMetadata.find(


### PR DESCRIPTION
Table columns should only be reconfigured:

- for differential results, after test changes
- for enrichment results, after database changes

This sets state (e.g. differentialColumnsConfigured: true) and resets it to false (according to above) to prevent recalling the config function.

See task details/conversation here: https://jira.abbvienet.com/browse/IPAD-396