### PR TITLE
[IPAD-400] Move column config flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "dependencies": {
         "@observablehq/stdlib": "^3.3.0",
         "airbnb-prop-types": "^2.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "private": true,
   "dependencies": {
     "@observablehq/stdlib": "^3.3.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -38,6 +38,7 @@ class Differential extends Component {
     super(props);
     // this.resizeListener = this.resizeListener.bind(this);
     // this.debouncedResizeListener = _.debounce(this.resizeListener, 100);
+    this.differentialColumnsConfigured = false;
     this.state = {
       // GENERAL
       // differentialPlotTypes: [],
@@ -57,7 +58,6 @@ class Differential extends Component {
        * @type {QHGrid.ColumnConfig[]}
        */
       differentialColumns: [],
-      differentialColumnsConfigured: false,
       isSearchingDifferential: false,
       isValidSearchDifferential: false,
       isFilteredDifferential: false,
@@ -147,9 +147,7 @@ class Differential extends Component {
   };
 
   handleDifferentialColumnsConfigured = bool => {
-    this.setState({
-      differentialColumnsConfigured: bool,
-    });
+    this.differentialColumnsConfigured = bool;
   };
 
   handleSearchTransitionDifferentialAlt = bool => {
@@ -193,13 +191,13 @@ class Differential extends Component {
     // need this check for page refresh
     if (
       searchResults?.differentialResults?.length &&
-      !this.state.differentialColumnsConfigured
+      !this.differentialColumnsConfigured
     ) {
       let columns = this.getConfigCols(searchResults);
       this.setState({
-        differentialColumnsConfigured: true,
         differentialColumns: columns,
       });
+      this.differentialColumnsConfigured = true;
     }
     this.setState({
       differentialResults: searchResults.differentialResults,

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -40,6 +40,7 @@ class Enrichment extends Component {
   storedEnrichmentActiveIndex =
     parseInt(sessionStorage.getItem('enrichmentViewTab'), 10) || 0;
 
+  enrichmentColumnsConfigured = false;
   state = {
     pValueType: sessionStorage.getItem('pValueType') || 'nominal',
     isValidSearchEnrichment: false,
@@ -48,7 +49,6 @@ class Enrichment extends Component {
     enrichmentResults: [],
     enrichmentColumns: [],
     enrichmentColumnsUnfiltered: [],
-    enrichmentColumnsConfigured: false,
     enrichmentFeatureID: '',
     enrichmentPlotSVGHeight: 0,
     enrichmentPlotSVGWidth: 0,
@@ -263,9 +263,7 @@ class Enrichment extends Component {
   };
 
   handleEnrichmentColumnsConfigured = bool => {
-    this.setState({
-      enrichmentColumnsConfigured: bool,
-    });
+    this.enrichmentColumnsConfigured = bool;
   };
 
   getThreePlotsFromUrl = (
@@ -448,12 +446,12 @@ class Enrichment extends Component {
     //   this.handleColumnReorder(searchResults);
     // }
     let columns = this.state.enrichmentColumnsUnfiltered || [];
-    if (searchResults?.length && !this.state.enrichmentColumnsConfigured) {
+    if (searchResults?.length && !this.enrichmentColumnsConfigured) {
       columns = this.getConfigCols(searchResults);
       this.setState({
-        enrichmentColumnsConfigured: true,
         enrichmentColumnsUnfiltered: columns,
       });
+      this.enrichmentColumnsConfigured = true;
     }
     if (multisetTestsFilteredOut.length > 0) {
       columns = columns.map(col => {
@@ -635,13 +633,13 @@ class Enrichment extends Component {
                 let columns = this.state.enrichmentColumnsUnfiltered || [];
                 if (
                   this.state.enrichmentResults?.length &&
-                  !this.state.enrichmentColumnsConfigured
+                  !this.enrichmentColumnsConfigured
                 ) {
                   columns = this.getConfigCols(this.state.enrichmentResults);
                   this.setState({
-                    enrichmentColumnsConfigured: true,
                     enrichmentColumnsUnfiltered: columns,
                   });
+                  this.enrichmentColumnsConfigured = true;
                 }
                 if (this.state.multisetTestsFilteredOut.length > 0) {
                   const self = this;
@@ -691,16 +689,13 @@ class Enrichment extends Component {
                   let columns = this.state.enrichmentColumnsUnfiltered || [];
                   if (
                     this.state.enrichmentResults?.length &&
-                    !this.state.enrichmentColumnsConfigured
+                    !this.enrichmentColumnsConfigured
                   ) {
                     columns = this.getConfigCols(this.state.enrichmentResults);
                     this.setState({
-                      enrichmentColumnsConfigured: true,
                       enrichmentColumnsUnfiltered: columns,
                     });
-                    console.log(
-                      'enrichment config cols - see this just one per db',
-                    );
+                    this.enrichmentColumnsConfigured = true;
                   }
                   if (self.state.multisetTestsFilteredOut.length > 0) {
                     columns = columns.filter(function(col) {

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.6.5',
+      appVersion: '1.6.6',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
Fix bug with cached data by moving the column config flag from async state to sync this.

To test: select any study/model/test combination. Switch to another a different study/model/test combo.  Navigate back to the first and confirm the columns are correct.