### PR TITLE
[IPAD-401] Scatterplot axis & multiset column defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "dependencies": {
         "@observablehq/stdlib": "^3.3.0",
         "airbnb-prop-types": "^2.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "private": true,
   "dependencies": {
     "@observablehq/stdlib": "^3.3.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -50,10 +50,12 @@ class DifferentialDetail extends Component {
     visible: false,
     allChecked: false,
     enableTabChangeOnSelection: true,
+    scatterplotLoaded: false,
   };
   volcanoPlotFilteredGridRef = React.createRef();
 
   componentDidMount() {
+    debugger;
     this.setState({
       differentialTableData: this.props.differentialResults,
       // volcanoPlotRows: this.props.differentialResults.length,
@@ -63,6 +65,7 @@ class DifferentialDetail extends Component {
   componentDidUpdate(prevProps) {
     const { differentialResults } = this.props;
     if (prevProps.differentialResults !== differentialResults) {
+      debugger;
       this.setState({
         allChecked: false,
         differentialTableData: differentialResults,
@@ -234,6 +237,7 @@ class DifferentialDetail extends Component {
       );
     } else {
       // nothing is in box selection
+      debugger;
       this.props.onHandleHighlightedFeaturesDifferential([]);
       this.props.onResetDifferentialOutlinedFeature();
       this.pageToFeature();
@@ -604,6 +608,7 @@ class DifferentialDetail extends Component {
   };
 
   handleTableChange = () => {
+    debugger;
     let sortedFilteredData =
       this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.getSortedData() ||
       this.props.differentialResults;
@@ -611,6 +616,7 @@ class DifferentialDetail extends Component {
       {
         filteredDifferentialTableData: sortedFilteredData,
         // allChecked: false,
+        scatterplotLoaded: true,
       },
       function() {
         // DEV - test whether we want the rest of this in a callback, so scatter loads faster...

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -55,7 +55,6 @@ class DifferentialDetail extends Component {
   volcanoPlotFilteredGridRef = React.createRef();
 
   componentDidMount() {
-    debugger;
     this.setState({
       differentialTableData: this.props.differentialResults,
       // volcanoPlotRows: this.props.differentialResults.length,
@@ -65,7 +64,6 @@ class DifferentialDetail extends Component {
   componentDidUpdate(prevProps) {
     const { differentialResults } = this.props;
     if (prevProps.differentialResults !== differentialResults) {
-      debugger;
       this.setState({
         allChecked: false,
         differentialTableData: differentialResults,
@@ -237,7 +235,6 @@ class DifferentialDetail extends Component {
       );
     } else {
       // nothing is in box selection
-      debugger;
       this.props.onHandleHighlightedFeaturesDifferential([]);
       this.props.onResetDifferentialOutlinedFeature();
       this.pageToFeature();
@@ -608,7 +605,6 @@ class DifferentialDetail extends Component {
   };
 
   handleTableChange = () => {
-    debugger;
     let sortedFilteredData =
       this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.getSortedData() ||
       this.props.differentialResults;

--- a/src/components/Differential/DifferentialSearch.jsx
+++ b/src/components/Differential/DifferentialSearch.jsx
@@ -12,7 +12,7 @@ import {
 } from 'semantic-ui-react';
 import ndjsonStream from 'can-ndjson-stream';
 import { CancelToken } from 'axios';
-import { getDynamicSize, getWindowWidth } from '../Shared/helpers';
+import { getDynamicSize, getWindowWidth, getYAxis } from '../Shared/helpers';
 import '../Shared/Search.scss';
 import { omicNavigatorService } from '../../services/omicNavigator.service';
 import DifferentialMultisetFilters from './DifferentialMultisetFilters';
@@ -541,27 +541,10 @@ class DifferentialSearch extends Component {
       const { multisetColsDifferential } = this.props;
       // on toggle open
       if (this.state.selectedColP.length === 0) {
-        var defaultColKey = null;
         const multisetColsDifferentialKeys = multisetColsDifferential.map(
           t => t.key,
         );
-        if (multisetColsDifferentialKeys.includes('P_Value')) {
-          defaultColKey = 'P_Value';
-        } else if (multisetColsDifferentialKeys.includes('P.Value')) {
-          defaultColKey = 'P.Value';
-        } else if (multisetColsDifferentialKeys.includes('PValue')) {
-          defaultColKey = 'PValue';
-        } else if (multisetColsDifferentialKeys.includes('PVal')) {
-          defaultColKey = 'PVal';
-        } else if (multisetColsDifferentialKeys.includes('P value')) {
-          defaultColKey = 'P value';
-        } else if (multisetColsDifferentialKeys.includes('adj_P_Value')) {
-          defaultColKey = 'adj_P_Val';
-        } else if (multisetColsDifferentialKeys.includes('adj.P.Value')) {
-          defaultColKey = 'adj.P.Val';
-        } else {
-          defaultColKey = null;
-        }
+        let defaultColKey = getYAxis(multisetColsDifferentialKeys);
         let defaultCol = null;
         if (defaultColKey != null) {
           defaultCol = [

--- a/src/components/Differential/ScatterPlotDiv.jsx
+++ b/src/components/Differential/ScatterPlotDiv.jsx
@@ -69,6 +69,7 @@ class ScatterPlotDiv extends Component {
       yAxisLabel: null,
       volcanoCircleLabel: null,
       volcanoCircleLabels: [],
+      // DEV : do we want to reset these ^ ?
       optionsOpen: false,
       usageOpen: false,
     });
@@ -240,11 +241,14 @@ class ScatterPlotDiv extends Component {
       : null;
     // DOY
     let doY = this.state.doYAxisTransformation;
-    debugger;
     if (yLabel == null) {
       yLabel = getYAxis(relevantConfigColumns);
+      if (yLabel !== null) {
+        doY = true;
+      } else {
+        yLabel = relevantConfigColumns[0];
+      }
     }
-    debugger;
     const axes = relevantConfigColumns.map(e => {
       return {
         key: e,

--- a/src/components/Differential/ScatterPlotDiv.jsx
+++ b/src/components/Differential/ScatterPlotDiv.jsx
@@ -12,7 +12,11 @@ import {
   Dimmer,
   List,
 } from 'semantic-ui-react';
-import { isNotNANullUndefinedEmptyString } from '../Shared/helpers';
+import {
+  isNotNANullUndefinedEmptyString,
+  getYAxis,
+  getXAxis,
+} from '../Shared/helpers';
 import ButtonActions from '../Shared/ButtonActions';
 import ScatterPlot from './ScatterPlot';
 import './ScatterPlotDiv.scss';
@@ -226,11 +230,7 @@ class ScatterPlotDiv extends Component {
 
     // otherwise, if not cached in session, default to logFC. If no logFC, set to first index
     if (xLabel == null) {
-      if (relevantConfigColumns.indexOf('logFC') >= 0) {
-        xLabel = 'logFC';
-      } else {
-        xLabel = relevantConfigColumns[0];
-      }
+      xLabel = getXAxis(relevantConfigColumns);
     }
     // YAXIS
     let storedYAxisLabel = sessionStorage.getItem('yAxisLabel');
@@ -240,32 +240,11 @@ class ScatterPlotDiv extends Component {
       : null;
     // DOY
     let doY = this.state.doYAxisTransformation;
+    debugger;
     if (yLabel == null) {
-      if (relevantConfigColumns.indexOf('P_Value') >= 0) {
-        yLabel = 'P_Value';
-        doY = true;
-      } else if (relevantConfigColumns.indexOf('P.Value') >= 0) {
-        yLabel = 'P.Value';
-        doY = true;
-      } else if (relevantConfigColumns.indexOf('PValue') >= 0) {
-        yLabel = 'PValue';
-        doY = true;
-      } else if (relevantConfigColumns.indexOf('PVal') >= 0) {
-        yLabel = 'PVal';
-        doY = true;
-      } else if (relevantConfigColumns.indexOf('P value') >= 0) {
-        yLabel = 'P value';
-        doY = true;
-      } else if (relevantConfigColumns.indexOf('adj_P_Val') >= 0) {
-        yLabel = 'adj_P_Val';
-        doY = true;
-      } else if (relevantConfigColumns.indexOf('adj.P.Val') >= 0) {
-        yLabel = 'adj.P.Val';
-        doY = true;
-      } else {
-        yLabel = relevantConfigColumns[0];
-      }
+      yLabel = getYAxis(relevantConfigColumns);
     }
+    debugger;
     const axes = relevantConfigColumns.map(e => {
       return {
         key: e,

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -529,6 +529,10 @@ export function getXAxis(array) {
     if (
       // logfc
       columnLowerCase.includes('logfc') ||
+      columnLowerCase.includes('log.fc') ||
+      columnLowerCase.includes('log2fc') ||
+      columnLowerCase.includes('foldchange') ||
+      columnLowerCase.includes('fold change') ||
       columnLowerCase.includes('fc') ||
       columnLowerCase.includes('log')
     ) {

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -501,7 +501,6 @@ export function diff(from, to, field = 'id') {
 
 export function getYAxis(array) {
   const match = array.find(column => {
-    debugger;
     const columnLowerCase = column.toLowerCase();
     if (
       // p value
@@ -521,12 +520,11 @@ export function getYAxis(array) {
   if (match !== undefined) {
     // array contains substring match
     return match;
-  } else return array[0];
+  } else return null;
 }
 
 export function getXAxis(array) {
   const match = array.find(column => {
-    debugger;
     const columnLowerCase = column.toLowerCase();
     if (
       // logfc

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -498,3 +498,47 @@ export function diff(from, to, field = 'id') {
     added,
   };
 }
+
+export function getYAxis(array) {
+  const match = array.find(column => {
+    debugger;
+    const columnLowerCase = column.toLowerCase();
+    if (
+      // p value
+      columnLowerCase.includes('pval') ||
+      columnLowerCase.includes('p.val') ||
+      columnLowerCase.includes('p_val') ||
+      columnLowerCase.includes('p val') ||
+      // adjusted p value
+      columnLowerCase.includes('adjpval') ||
+      columnLowerCase.includes('adj.p.val') ||
+      columnLowerCase.includes('adj_p_val') ||
+      columnLowerCase.includes('adj p val')
+    ) {
+      return true;
+    } else return undefined;
+  });
+  if (match !== undefined) {
+    // array contains substring match
+    return match;
+  } else return array[0];
+}
+
+export function getXAxis(array) {
+  const match = array.find(column => {
+    debugger;
+    const columnLowerCase = column.toLowerCase();
+    if (
+      // logfc
+      columnLowerCase.includes('logfc') ||
+      columnLowerCase.includes('fc') ||
+      columnLowerCase.includes('log')
+    ) {
+      return true;
+    } else return undefined;
+  });
+  if (match !== undefined) {
+    // array contains substring match
+    return match;
+  } else return array[0];
+}

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.6.6',
+      appVersion: '1.6.7',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
Scatterplot axis labels are cached for a given study/model/test.  However, when they are first set, we "sniff" for certain values.  The way this was coded looks for a variety of different values, but in their entirety (**indexOf**), not substrings of them.  So labels like PValue.Blah wouldn't get picked up, and the fallback is the zero index of the columns array.  I've changed the code to look for the inclusion of substrings, so PValue.Blah will be valid for the default. To make this easier, I **lowercase** the columns, and run **.includes**.

Now we are sniffing for:
1) Scatterplot "X Axis":   logfc, log.fc, log2fc, foldchange, fold change, fc, log
2) Scatterplot "Y Axis": pval, p.val, p_val, p val, adjpval, adj.p.val, adj_p_val, adj p val
3) Multiset "Column": pval, p.val, p_val, p val, adjpval, adj.p.val, adj_p_val, adj p val