### PR TITLE
[IPAD-403] - Fix d3.select invalid selectors

### DIFF
--- a/src/components/Differential/ScatterPlot.jsx
+++ b/src/components/Differential/ScatterPlot.jsx
@@ -1402,7 +1402,7 @@ class ScatterPlot extends Component {
         // transition ticks
         self.xxAxis = d3.axisTop(xScale).ticks();
         self.yyAxis = d3.axisRight(yScale).ticks();
-        let t = d3.select('svg');
+        d3.select('svg');
         // .transition()
         // .duration(200);
         d3.select('#xaxis-line')

--- a/src/components/Enrichment/BarcodePlot.jsx
+++ b/src/components/Enrichment/BarcodePlot.jsx
@@ -76,13 +76,17 @@ class BarcodePlot extends Component {
           const OtherFeatures = HighlightedProteinsCopy.slice(1);
           OtherFeatures.forEach(element => {
             const lineId = `${element.featureID}`;
-            const OtherHighlighted = d3.select(`#barcode-line-${lineId}`);
+            const OtherHighlighted = d3.select(
+              `line[id='barcode-line-${lineId}']`,
+            );
             OtherHighlighted.classed('HighlightedLine', true)
               .attr('y1', this.state.settings.margin.highlighted)
               .attr('style', 'stroke:#ff7e38;stroke-width:3');
           });
           const MaxFeatureId = MaxFeatureData.featureID;
-          const MaxFeatureElement = d3.select(`#barcode-line-${MaxFeatureId}`);
+          const MaxFeatureElement = d3.select(
+            `line[id='barcode-line-${MaxFeatureId}']`,
+          );
           if (MaxFeatureElement != null) {
             MaxFeatureElement.classed('MaxLine', true)
               .attr('y1', this.state.settings.margin.max)
@@ -163,7 +167,8 @@ class BarcodePlot extends Component {
         ? event.target.attributes[2].nodeValue - 5
         : event.target.attributes[2].nodeValue + 5;
     const lineId = `#barcode-line-${lineIdMult}`;
-    const hoveredLine = d3.select(lineId);
+    const hoveredLine = d3.select(`line[id='barcode-line-${lineIdMult}']`);
+    // const hoveredLine = d3.select(lineId);
     if (hoveredLine.attr('class').endsWith('selected')) {
       hoveredLine.attr('y1', this.state.settings.margin.selected - 10);
     } else if (hoveredLine.attr('class').endsWith('MaxLine')) {
@@ -335,7 +340,7 @@ class BarcodePlot extends Component {
             if (brushedDataVar.length > 0) {
               const maxLineObject = self.getMaxObject(brushedDataVar);
               const maxLineId = `${maxLineObject.lineID}`;
-              const maxLine = d3.select(`#barcode-line-${maxLineId}`);
+              const maxLine = d3.select(`line[id='barcode-line-${maxLineId}']`);
               maxLine
                 .classed('MaxLine', true)
                 .attr('style', 'stroke:#FF4400;stroke-width:3.5')

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -189,7 +189,6 @@ class Enrichment extends Component {
     previousEnrichmentModel: '',
     previousEnrichmentAnnotation: '',
     multisetTestsFilteredOut: [],
-    enrichmentColumnsUnfiltered: [],
     itemsPerPageEnrichmentTable:
       parseInt(localStorage.getItem('itemsPerPageEnrichmentTable'), 10) || 30,
     isDataStreamingEnrichmentsTable: false,

--- a/src/components/Enrichment/ViolinPlot.jsx
+++ b/src/components/Enrichment/ViolinPlot.jsx
@@ -75,7 +75,7 @@ class ViolinPlot extends Component {
       if (HighlightedProteins.length > 0) {
         HighlightedProteins.forEach(element => {
           const highlightedDotId = element.featureID;
-          const dot = d3.select(`#violin_${highlightedDotId}`);
+          const dot = d3.select(`circle[id='violin_${highlightedDotId}']`);
           dot
             .transition()
             .duration(100)
@@ -98,7 +98,7 @@ class ViolinPlot extends Component {
       // if max protein exists, get id
       if (HighlightedProteins[0]?.featureID) {
         const maxDotId = HighlightedProteins[0].featureID;
-        d3.select(`#violin_${maxDotId}`)
+        d3.select(`circle[id='violin_${maxDotId}']`)
           .transition()
           .duration(100)
           .attr('fill', '#FF4400')
@@ -106,7 +106,7 @@ class ViolinPlot extends Component {
           .attr('r', dOpts.pointSize * 2);
         this.maxCircle = maxDotId;
         this.addToolTiptoMax(HighlightedProteins[0]);
-        d3.select(`#violin_${maxDotId}`).raise();
+        d3.select(`circle[id='violin_${maxDotId}']`).raise();
       }
       const opacityVar = this.state.displayElementTextViolin ? 1 : 0;
       chartSVG.selectAll('g.circleText').attr('opacity', opacityVar);
@@ -221,9 +221,13 @@ class ViolinPlot extends Component {
   addToolTiptoMax = id => {
     if (id != null) {
       const self = this;
-      d3.select(`#violin_${id.featureID}`);
-      const cx = Math.ceil(d3.select(`#violin_${id.featureID}`).attr('cx'));
-      const cy = Math.ceil(d3.select(`#violin_${id.featureID}`).attr('cy'));
+      d3.select(`circle[id='violin_${id.featureID}']`);
+      const cx = Math.ceil(
+        d3.select(`circle[id='violin_${id.featureID}']`).attr('cx'),
+      );
+      const cy = Math.ceil(
+        d3.select(`circle[id='violin_${id.featureID}']`).attr('cy'),
+      );
 
       const svg = document.getElementById(`${this.props.violinSettings.id}`);
       let parent = '';
@@ -1494,13 +1498,13 @@ class ViolinPlot extends Component {
               // self.dotHover.emit({ object: d, action: 'mouseover' });
               self.isHovering = true;
               if (self.maxCircle === d.featureID) {
-                d3.select(`#violin_${d.featureID}`)
+                d3.select(`circle[id='violin_${d.featureID}']`)
                   .transition()
                   .duration(100)
                   .attr('cursor', 'pointer')
                   .attr('r', dOpts.pointSize * 2.5);
               } else {
-                d3.select(`#violin_${d.featureID}`)
+                d3.select(`circle[id='violin_${d.featureID}']`)
                   .transition()
                   .duration(100)
                   .attr('cursor', 'pointer')
@@ -1527,7 +1531,7 @@ class ViolinPlot extends Component {
             })
             .on('mouseout', d => {
               // var id = d.sample.replace(/\;/g, "_");
-              d3.select(`#violin_${d.featureID}`)
+              d3.select(`circle[id='violin_${d.featureID}']`)
                 .transition()
                 .duration(300)
                 .attr('r', x => {


### PR DESCRIPTION
The semi-colons in the feature ids for study "Liver Tropism" were causing breaking errors in the enrichment triple-pane view. I'm not sure why semi-colons within CSS selectors are considered invalid (like period or space - which would represent a class, or a child), however the change to this alternative CSS selection method fixed the issues.
Example: Before - d3.select('#barcode-line-featureId'); After - d3.select('line[id="barcode-line-featureId"]')

Note: you can review on .173 (go/on-dev), where I've merged the branch to facilitate testing