### PR TITLE
[IPAD-404] - cached enrichment results config columns bug

### DIFF
--- a/src/components/Differential/DifferentialSearch.jsx
+++ b/src/components/Differential/DifferentialSearch.jsx
@@ -362,8 +362,11 @@ class DifferentialSearch extends Component {
       onSearchChangeDifferential,
       onSearchResetDifferential,
       differentialModelsAndTests,
+      onHandlePlotTypesDifferential,
+      onHandleDifferentialColumnsConfigured,
     } = this.props;
-    this.props.onHandlePlotTypesDifferential(value);
+    onHandleDifferentialColumnsConfigured(false);
+    onHandlePlotTypesDifferential(value);
     onSearchChangeDifferential(
       {
         differentialStudy: differentialStudy,

--- a/src/components/Enrichment/EnrichmentSearch.jsx
+++ b/src/components/Enrichment/EnrichmentSearch.jsx
@@ -351,7 +351,9 @@ class EnrichmentSearch extends Component {
       onSearchChangeEnrichment,
       onSearchResetEnrichment,
       enrichmentModelsAndAnnotations,
+      onHandleEnrichmentColumnsConfigured,
     } = this.props;
+    onHandleEnrichmentColumnsConfigured(false);
     this.props.onHandleHasBarcodeData();
     this.props.onHandlePlotTypesEnrichment(value);
     onSearchChangeEnrichment(


### PR DESCRIPTION
I cannot replicate the bug for [IPAD-404](https://jira.abbvienet.com/browse/IPAD-404) locally on .184 nor .173.  However, we can tell that the columns are not being re-configured when returning to a study/model/db that already has cached enrichment results table.  This PR just sets the columns configured value back to false after a model is changed, since doing it on test/database change doesn't seem to be enough.