### PR TITLE
[IPAD-402] Fix brush bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.6.9",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.6.9",
+      "version": "1.7.0",
       "dependencies": {
         "@observablehq/stdlib": "^3.3.0",
         "airbnb-prop-types": "^2.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.6.9",
+  "version": "1.7.0",
   "private": true,
   "dependencies": {
     "@observablehq/stdlib": "^3.3.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.6.9",
+  "version": "1.7.0",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Enrichment/BarcodePlot.jsx
+++ b/src/components/Enrichment/BarcodePlot.jsx
@@ -412,7 +412,7 @@ class BarcodePlot extends Component {
           quartileTicks.nodes()[0].getAttribute('x1'),
         ]);
       }, 500);
-      d3.select('.overlay').remove();
+      d3.select('.barcodeBrush rect.overlay').remove();
     } else {
       // reposition the brushed rect on window resize, or horizontal pane resize
       const selectedTicks = d3.selectAll('line').filter(function() {
@@ -425,7 +425,7 @@ class BarcodePlot extends Component {
           selectedTicks.nodes()[0].getAttribute('x1'),
         ]);
       }
-      d3.select('.overlay').remove();
+      d3.select('.barcodeBrush rect.overlay').remove();
     }
   }
 

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.6.9',
+      appVersion: '1.7.0',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
Duplicated issue every time when a scatter plot is in view, and then a barcode plot is rendered.  There is a function that removes the d3 element class 'overlay' and it is too general; the overlay for the scatter plot exists in the DOM and is removed. To fix, I've specified the specific overlay to remove:  d3.select('.barcodeBrush rect.overlay').remove();