### PR TITLE
[IPAD-410] Fix scatter plot label bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "@observablehq/stdlib": "^3.3.0",
         "airbnb-prop-types": "^2.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "dependencies": {
     "@observablehq/stdlib": "^3.3.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Differential/ScatterPlot.jsx
+++ b/src/components/Differential/ScatterPlot.jsx
@@ -362,7 +362,7 @@ class ScatterPlot extends Component {
   }
 
   hexBinning(data) {
-    if (data.length > 2500) {
+    if (data.length >= 2500) {
       const { xScale, yScale } = this.scaleFactory(data);
       const { bins, circles } = this.parseDataToBinsAndCircles(
         data,
@@ -381,12 +381,22 @@ class ScatterPlot extends Component {
         },
       );
     } else {
-      this.scaleFactory(data);
-      this.renderCircles(data);
-      this.unhighlightCirclesAndBinsAndLabels();
-      this.highlightCirclesAndBins();
-      this.outlineCircleOrBin();
-      this.handleCircleLabels();
+      this.setState(
+        {
+          bins: [],
+          circles: data,
+          relevantCircles: data,
+          relevantBins: [],
+        },
+        function() {
+          this.scaleFactory(data);
+          this.renderCircles(data);
+          this.unhighlightCirclesAndBinsAndLabels();
+          this.highlightCirclesAndBins();
+          this.outlineCircleOrBin();
+          this.handleCircleLabels();
+        },
+      );
     }
   }
 

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.7.0',
+      appVersion: '1.7.1',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
In datasets with fewer than 2500 features, `circles` and `relevantCircles` state wasn't being set for the scatterplot, and therefore couldn't be read for labels.

To test: ensure scatter plot circle labels work for datasets with fewer than 2500 features, for example: http://localhost:3000/#/differential/D07282022.D20210927.W210488.Hs.Human.skin.LCM/Protein_Expression/Epidermis.vs.HS_Epithelium