### PR TITLE
[IPAD_421] Fix network graph bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "dependencies": {
         "@observablehq/stdlib": "^3.3.0",
         "airbnb-prop-types": "^2.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "dependencies": {
     "@observablehq/stdlib": "^3.3.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Enrichment/NetworkGraph.jsx
+++ b/src/components/Enrichment/NetworkGraph.jsx
@@ -916,7 +916,6 @@ class NetworkGraph extends Component {
                           ? `${d3.event.pageY - 100}px`
                           : `${d3.event.pageY - 15}px`;
                       let pValueDisplay;
-                      debugger;
                       if (Math.abs(d.data.value) > 0.001)
                         pValueDisplay = d.data.value?.toPrecision(3) || 'N/A';
                       else

--- a/src/components/Enrichment/NetworkGraph.jsx
+++ b/src/components/Enrichment/NetworkGraph.jsx
@@ -916,9 +916,11 @@ class NetworkGraph extends Component {
                           ? `${d3.event.pageY - 100}px`
                           : `${d3.event.pageY - 15}px`;
                       let pValueDisplay;
+                      debugger;
                       if (Math.abs(d.data.value) > 0.001)
-                        pValueDisplay = d.data.value.toPrecision(3);
-                      else pValueDisplay = d.data.value.toExponential(3);
+                        pValueDisplay = d.data.value?.toPrecision(3) || 'N/A';
+                      else
+                        pValueDisplay = d.data.value?.toExponential(3) || 'N/A';
                       div
                         .html(
                           `<div className="tooltipLink"><b>Description: </b>${d.data.metaData.description}<br/><b>Test: </b>${d.data.prop}<br/><b><span className="textTransformCapitalize">${pValueType}</span> P Value: </b>${pValueDisplay}<br/><b>Ontology: </b>${d.data.metaData.termID}</div>`,

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -564,7 +564,6 @@ export function getIdArg(
   multiModelMappingArrays,
   id,
 ) {
-  debugger;
   // if plot type does not include 'multiModel', return just the id
   if (!plotType.includes('multiModel')) {
     return id;

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.7.2',
+      appVersion: '1.7.3',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
Handle undefined p-values in the network graph. To test, in the network graph, hover over a node with a grey pie (undefined). For example: http://localhost:3000/#/enrichment/D07282022.D20210927.W210488.Hs.Human.skin.LCM/VisiumHS/GO_enrich