### PR TITLE
[IPAD-424] Fix export of feature metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "dependencies": {
         "@observablehq/stdlib": "^3.3.0",
         "airbnb-prop-types": "^2.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "dependencies": {
     "@observablehq/stdlib": "^3.3.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -559,6 +559,7 @@ class DifferentialDetail extends Component {
   };
 
   handleSizeChange = (newSize, axisDragged) => {
+    if (newSize === undefined) return;
     const { volcanoDivWidth } = this.state;
     const { fwdRefDVC } = this.props;
     const plotSizeAdjustment = Math.round(newSize * 0.9);

--- a/src/components/Differential/MetafeaturesTable.jsx
+++ b/src/components/Differential/MetafeaturesTable.jsx
@@ -20,7 +20,6 @@ class MetafeaturesTable extends Component {
       parseInt(localStorage.getItem('itemsPerPageMetafeaturesTable'), 10) || 60,
     additionalTemplateInfo: [],
   };
-  metafeaturesGridRef = React.createRef();
 
   componentDidMount() {
     const isMultifeaturePlot =
@@ -189,7 +188,7 @@ class MetafeaturesTable extends Component {
     return (
       <div className="MetafeaturesTableDiv">
         <EZGrid
-          ref={this.metafeaturesGridRef}
+          ref={this.props.metafeaturesTableRef}
           data={metafeaturesTableData}
           columnsConfig={metafeaturesTableConfigCols}
           totalRows={15}
@@ -215,4 +214,6 @@ class MetafeaturesTable extends Component {
   }
 }
 
-export default MetafeaturesTable;
+export default React.forwardRef((props, ref) => (
+  <MetafeaturesTable {...props} metafeaturesTableRef={ref} />
+));

--- a/src/components/Differential/MetafeaturesTableDynamic.jsx
+++ b/src/components/Differential/MetafeaturesTableDynamic.jsx
@@ -21,7 +21,6 @@ class MetafeaturesTableDynamic extends Component {
     additionalTemplateInfo: [],
     metafeaturesLoaded: false,
   };
-  metafeaturesGridRefDynamic = React.createRef();
 
   componentDidMount() {
     const isMultifeaturePlot =
@@ -209,7 +208,7 @@ class MetafeaturesTableDynamic extends Component {
     return (
       <div className="MetafeaturesTableDiv" id="MetafeaturesTableDynamicDiv">
         <EZGrid
-          ref={this.metafeaturesGridRefDynamic}
+          ref={this.props.metafeaturesTableDynamicRef}
           data={metafeaturesTableData}
           columnsConfig={metafeaturesTableConfigCols}
           totalRows={15}
@@ -235,4 +234,6 @@ class MetafeaturesTableDynamic extends Component {
   }
 }
 
-export default MetafeaturesTableDynamic;
+export default React.forwardRef((props, ref) => (
+  <MetafeaturesTableDynamic {...props} metafeaturesTableDynamicRef={ref} />
+));

--- a/src/components/Differential/PlotsOverlay.jsx
+++ b/src/components/Differential/PlotsOverlay.jsx
@@ -23,6 +23,7 @@ class PlotsOverlay extends PureComponent {
       plotlyExport: false,
       plotlyExportType: 'svg',
     };
+    this.metafeaturesTableRef = React.createRef();
   }
 
   metaFeaturesTableRef = React.createRef();
@@ -185,10 +186,7 @@ class PlotsOverlay extends PureComponent {
                     pdfVisible={pdfFlag}
                     svgVisible={svgFlag}
                     txtVisible={txtFlag}
-                    refFwd={
-                      this.metaFeaturesTableRef.current?.metafeaturesGridRef ||
-                      null
-                    }
+                    refFwd={this.metafeaturesTableRef}
                     tab={tab}
                     study={differentialStudy}
                     model={differentialModel}
@@ -227,6 +225,7 @@ class PlotsOverlay extends PureComponent {
                       differentialPlotsOverlayRefFwd={
                         this.differentialPlotsOverlayRef
                       }
+                      ref={this.metafeaturesTableRef}
                       // DEV - add only necessary props
                       // activeTabIndexPlotsMultiFeature={activeTabIndexPlotsMultiFeature}
                       // differentialDetailPlotsMultiFeatureRefFwd={

--- a/src/components/Differential/PlotsSingleFeature.jsx
+++ b/src/components/Differential/PlotsSingleFeature.jsx
@@ -17,7 +17,7 @@ class PlotsSingleFeature extends Component {
   };
 
   differentialDetailPlotsSingleFeatureRef = React.createRef();
-  metaFeaturesTableDynamicRef = React.createRef();
+  metafeaturesTableDynamicRef = React.createRef();
 
   componentDidMount() {
     this.setButtonVisibility();
@@ -176,10 +176,7 @@ class PlotsSingleFeature extends Component {
                 imageInfo={plotSingleFeatureData}
                 tabIndex={activeTabIndexPlotsSingleFeatureVar}
                 svgExportName={svgExportName}
-                refFwd={
-                  this.metaFeaturesTableDynamicRef.current
-                    ?.metafeaturesGridRefDynamic || null
-                }
+                refFwd={this.metafeaturesTableDynamicRef}
                 study={differentialStudy}
                 model={differentialModel}
                 test={differentialTest}
@@ -213,6 +210,7 @@ class PlotsSingleFeature extends Component {
               differentialDetailPlotsSingleFeatureRefFwd={
                 this.differentialDetailPlotsSingleFeatureRef
               }
+              ref={this.metafeaturesTableDynamicRef}
             />
             <span
               className={divWidth < 450 ? 'Hide' : 'Show'}

--- a/src/components/Differential/TabOverlay.jsx
+++ b/src/components/Differential/TabOverlay.jsx
@@ -141,7 +141,7 @@ class TabOverlay extends Component {
             render: () => (
               <Tab.Pane attached="true" as="div">
                 <MetafeaturesTable
-                  ref={this.metaFeaturesTableRef}
+                  ref={this.props.metafeaturesTableRef}
                   differentialStudy={this.props.differentialStudy}
                   differentialModel={this.props.differentialModel}
                   differentialFeature={this.props.differentialFeature}
@@ -179,4 +179,6 @@ class TabOverlay extends Component {
   }
 }
 
-export default TabOverlay;
+export default React.forwardRef((props, ref) => (
+  <TabOverlay {...props} metafeaturesTableRef={ref} />
+));

--- a/src/components/Differential/TabSingleFeature.jsx
+++ b/src/components/Differential/TabSingleFeature.jsx
@@ -115,7 +115,7 @@ class TabSingleFeature extends Component {
             render: () => (
               <Tab.Pane attached="true" as="div">
                 <MetafeaturesTableDynamic
-                  ref={this.metaFeaturesTableDynamicRef}
+                  ref={this.props.metafeaturesTableDynamicRef}
                   differentialStudy={differentialStudy}
                   differentialModel={differentialModel}
                   plotOverlayLoaded={plotOverlayLoaded}
@@ -151,4 +151,6 @@ class TabSingleFeature extends Component {
   }
 }
 
-export default TabSingleFeature;
+export default React.forwardRef((props, ref) => (
+  <TabSingleFeature {...props} metafeaturesTableDynamicRef={ref} />
+));

--- a/src/components/Enrichment/SplitPanesContainer.jsx
+++ b/src/components/Enrichment/SplitPanesContainer.jsx
@@ -204,6 +204,7 @@ class SplitPanesContainer extends Component {
   };
 
   splitPaneResized = (size, paneType) => {
+    if (size === undefined) return;
     if (paneType === 'horizontal') {
       this.setState({
         horizontalSplitPaneSize: size,

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.7.3',
+      appVersion: '1.7.4',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
**Bug**: Export of the feature data tables was broken in both the dynamic triple pane and the overlay, because the reference ("ref") was undefined
**Fix**: use React's "forwardRef" to allow the child component to pass the table ref to it's parent/s
**Test**: export both .xls and .txt in the following views:

dynamic triple pane:
<img width="643" alt="Screen Shot 2022-11-28 at 2 11 05 PM" src="https://user-images.githubusercontent.com/10191004/204377326-bc62428a-470b-466a-8654-e0e7d1f5226e.png">

overlay:
<img width="643" alt="Screen Shot 2022-11-28 at 2 11 34 PM" src="https://user-images.githubusercontent.com/10191004/204377345-f188ca7f-56dd-4d87-a2c8-a7feed383e48.png">