### PR TITLE
[IPAD-411] Account for missing barcode

### DIFF
--- a/src/components/Enrichment/BarcodePlot.jsx
+++ b/src/components/Enrichment/BarcodePlot.jsx
@@ -543,7 +543,7 @@ class BarcodePlot extends Component {
     // featureID: "17747_1"
     // logFoldChange: 0
     // statistic: 19.0484
-    const barcodeLines = barcodeSettings.barcodeData.map(d => (
+    const barcodeLines = barcodeSettings.barcodeData?.map(d => (
       <line
         id={`barcode-line-${d.featureID}`}
         className="barcode-line"

--- a/src/components/Enrichment/BarcodePlot.jsx
+++ b/src/components/Enrichment/BarcodePlot.jsx
@@ -410,8 +410,8 @@ class BarcodePlot extends Component {
       const quartile = Math.round(quartileTicks.nodes().length * 0.25);
       setTimeout(function() {
         d3.select('.barcodeBrush').call([objsBrush][0].move, [
-          quartileTicks.nodes()[quartile].getAttribute('x1'),
-          quartileTicks.nodes()[0].getAttribute('x1'),
+          quartileTicks.nodes()[quartile]?.getAttribute('x1'),
+          quartileTicks.nodes()[0]?.getAttribute('x1'),
         ]);
       }, 500);
       d3.select('.barcodeBrush rect.overlay').remove();

--- a/src/components/Enrichment/BarcodePlot.jsx
+++ b/src/components/Enrichment/BarcodePlot.jsx
@@ -41,6 +41,7 @@ class BarcodePlot extends Component {
   barcodeSVGRef = React.createRef();
 
   componentDidMount() {
+    if (!this.props.hasBarcodeData) return;
     this.setWidth(true, false);
     let resizedFn;
     window.addEventListener('resize', () => {
@@ -52,6 +53,7 @@ class BarcodePlot extends Component {
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
+    if (!this.props.hasBarcodeData) return;
     if (
       this.props.horizontalSplitPaneSize !== prevProps.horizontalSplitPaneSize
     ) {
@@ -496,7 +498,13 @@ class BarcodePlot extends Component {
       displayElementTextBarcode,
     } = this.state;
 
-    const { horizontalSplitPaneSize, barcodeSettings } = this.props;
+    const {
+      horizontalSplitPaneSize,
+      barcodeSettings,
+      hasBarcodeData,
+    } = this.props;
+    if (!hasBarcodeData) return null;
+
     const barcodeHeight =
       horizontalSplitPaneSize - settings.margin.top - settings.margin.bottom;
 

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -977,18 +977,14 @@ class Enrichment extends Component {
               <Popup
                 trigger={
                   <span
-                    className={hasBarcodeData ? 'TableCellLink' : ''}
-                    onClick={
-                      hasBarcodeData
-                        ? addParams.barcodeData(
-                            enrichmentStudy,
-                            enrichmentModel,
-                            enrichmentAnnotation,
-                            item,
-                            c,
-                          )
-                        : {}
-                    }
+                    className="TableCellLink"
+                    onClick={addParams.barcodeData(
+                      enrichmentStudy,
+                      enrichmentModel,
+                      enrichmentAnnotation,
+                      item,
+                      c,
+                    )}
                   >
                     {formatNumberForDisplay(value)}
                   </span>

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -34,6 +34,7 @@ import ErrorBoundary from '../Shared/ErrorBoundary';
 
 let cancelRequestEnrichmentGetPlot = () => {};
 let cancelRequestGetEnrichmentsNetwork = () => {};
+let cancelRequestGetBarcodeData = () => {};
 const cacheGetEnrichmentsNetwork = {};
 
 class Enrichment extends Component {
@@ -127,7 +128,7 @@ class Enrichment extends Component {
     SVGPlotLoading: false,
     SVGPlotLoaded: false,
     isViolinPlotLoaded: false,
-    hasBarcodeData: true,
+    hasBarcodeData: false,
     barcodeSettings: {
       barcodeData: [],
       brushedData: [],
@@ -306,7 +307,10 @@ class Enrichment extends Component {
       enrichmentTerm: term,
       enrichmentTest: test,
     });
-
+    cancelRequestGetBarcodeData();
+    let cancelToken = new CancelToken(e => {
+      cancelRequestGetBarcodeData = e;
+    });
     omicNavigatorService
       .getBarcodeData(
         enrichmentStudy,
@@ -315,7 +319,7 @@ class Enrichment extends Component {
         enrichmentAnnotation,
         term,
         this.handleGetBarcodeDataError,
-        null,
+        cancelToken,
       )
       .then(barcodeDataResponse => {
         if (barcodeDataResponse?.data?.length > 0) {
@@ -843,11 +847,7 @@ class Enrichment extends Component {
       enrichmentModel,
       enrichmentAnnotation,
     } = this.props;
-    const {
-      hasBarcodeData,
-      enrichmentsLinkouts,
-      enrichmentsFavicons,
-    } = this.state;
+    const { enrichmentsLinkouts, enrichmentsFavicons } = this.state;
     const TableValuePopupStyle = {
       backgroundColor: '2E2E2E',
       borderBottom: '2px solid var(--color-primary)',

--- a/src/components/Enrichment/FilteredDifferentialTable.jsx
+++ b/src/components/Enrichment/FilteredDifferentialTable.jsx
@@ -143,6 +143,8 @@ class FilteredDifferentialTable extends Component {
           this.props.enrichmentStudy,
           this.props.enrichmentModel,
           name,
+          this.props.enrichmentAnnotation,
+          this.props.enrichmentTerm,
           null,
           cancelToken,
         )

--- a/src/components/Enrichment/FilteredDifferentialTable.jsx
+++ b/src/components/Enrichment/FilteredDifferentialTable.jsx
@@ -101,7 +101,7 @@ class FilteredDifferentialTable extends Component {
   };
 
   getTableData = () => {
-    if (this.props.barcodeSettings.brushedData.length > 0) {
+    if (this.props.hasBarcodeData) {
       const brushedMultIds = this.props.barcodeSettings.brushedData.map(
         b => b.featureID,
       );
@@ -123,7 +123,7 @@ class FilteredDifferentialTable extends Component {
       });
     } else {
       this.setState({
-        filteredTableData: [],
+        filteredTableData: this.state.filteredBarcodeData,
       });
     }
   };
@@ -146,9 +146,12 @@ class FilteredDifferentialTable extends Component {
           null,
           cancelToken,
         )
-        .then(dataFromService => {
-          if (dataFromService.length > 0) {
-            this.setConfigCols(barcodeData, dataFromService, false);
+        .then(filteredDifferentialResults => {
+          if (filteredDifferentialResults.length > 0) {
+            this.setConfigCols(barcodeData, filteredDifferentialResults, false);
+            this.props.onSetFilteredDifferentialResults(
+              filteredDifferentialResults,
+            );
           }
         })
         .catch(error => {
@@ -157,7 +160,13 @@ class FilteredDifferentialTable extends Component {
     }
   };
 
-  setConfigCols = (data, dataFromService, dataAlreadyFiltered) => {
+  setConfigCols = (
+    barcodeData,
+    filteredDifferentialResults,
+    dataAlreadyFiltered,
+  ) => {
+    const { hasBarcodeData } = this.props;
+    let data = hasBarcodeData ? barcodeData : [...filteredDifferentialResults];
     const {
       filteredDifferentialLinkouts,
       filteredDifferentialFavicons,
@@ -173,16 +182,18 @@ class FilteredDifferentialTable extends Component {
     };
     let filteredDifferentialAlphanumericFields = [];
     let filteredDifferentialNumericFields = [];
-    if (dataFromService.length < 1) return;
+    if (filteredDifferentialResults.length < 1) return;
     // grab first object
     const firstFullObject =
-      dataFromService.length > 0 ? [...dataFromService][0] : null;
+      filteredDifferentialResults.length > 0
+        ? [...filteredDifferentialResults][0]
+        : null;
     // if exists, loop through the values of each property,
     // find the first real value,
     // and set the config column types
     if (firstFullObject) {
       let allProperties = Object.keys(firstFullObject);
-      const dataCopy = [...dataFromService];
+      const dataCopy = [...filteredDifferentialResults];
       allProperties.forEach(property => {
         // loop through data, one property at a time
         const notNullObject = dataCopy.find(row => {
@@ -209,14 +220,15 @@ class FilteredDifferentialTable extends Component {
       });
     }
     const alphanumericTrigger = filteredDifferentialAlphanumericFields[0];
+    let featureID = hasBarcodeData ? 'featureID' : alphanumericTrigger;
     this.props.onHandleDifferentialFeatureIdKey(
       'filteredDifferentialFeatureIdKey',
       alphanumericTrigger,
     );
     this.setState({ identifier: alphanumericTrigger });
     if (!dataAlreadyFiltered) {
-      const barcodeMultIds = data.map(b => b.featureID);
-      data = dataFromService.filter(d =>
+      const barcodeMultIds = data.map(b => b[featureID]);
+      data = filteredDifferentialResults.filter(d =>
         barcodeMultIds.includes(d[alphanumericTrigger]),
       );
     }

--- a/src/components/Enrichment/SplitPanesContainer.jsx
+++ b/src/components/Enrichment/SplitPanesContainer.jsx
@@ -218,8 +218,7 @@ class SplitPanesContainer extends Component {
 
   render() {
     const { verticalSplitPaneSize, horizontalSplitPaneSize } = this.state;
-    const { enrichmentStudy, enrichmentModel } = this.props;
-    const BarcodePlot = this.getBarcodePlot();
+    const { enrichmentStudy, enrichmentModel, hasBarcodeData } = this.props;
     const ViolinAndTable = this.getViolinAndTable();
     const width =
       window.innerWidth ||
@@ -230,47 +229,120 @@ class SplitPanesContainer extends Component {
       document.documentElement.clientHeight ||
       document.body.clientHeight;
 
-    return (
-      <div className="PlotsWrapper">
-        <Grid className="">
-          <Grid.Row className="ActionsRow">
-            <Grid.Column
-              mobile={16}
-              tablet={16}
-              computer={8}
-              largeScreen={8}
-              widescreen={8}
-            >
-              <EnrichmentBreadcrumbs {...this.props} />
-            </Grid.Column>
-            <Grid.Column
-              mobile={16}
-              tablet={16}
-              computer={8}
-              largeScreen={8}
-              widescreen={8}
-              className="elementTextCol"
-            ></Grid.Column>
-
-            <Grid.Column
-              mobile={16}
-              tablet={16}
-              largeScreen={16}
-              widescreen={16}
-            >
-              <SplitPane
-                className="ThreePlotsDiv SplitPanesWrapper"
-                split="horizontal"
-                size={this.state.horizontalSplitPaneSize}
-                minSize={185}
-                maxSize={400}
-                onDragFinished={size =>
-                  this.splitPaneResized(size, 'horizontal')
-                }
+    if (hasBarcodeData) {
+      const BarcodePlot = this.getBarcodePlot();
+      return (
+        <div className="PlotsWrapper">
+          <Grid className="">
+            <Grid.Row className="ActionsRow">
+              <Grid.Column
+                mobile={16}
+                tablet={16}
+                computer={8}
+                largeScreen={8}
+                widescreen={8}
               >
-                {BarcodePlot}
+                <EnrichmentBreadcrumbs {...this.props} />
+              </Grid.Column>
+              <Grid.Column
+                mobile={16}
+                tablet={16}
+                computer={8}
+                largeScreen={8}
+                widescreen={8}
+                className="elementTextCol"
+              ></Grid.Column>
+
+              <Grid.Column
+                mobile={16}
+                tablet={16}
+                largeScreen={16}
+                widescreen={16}
+              >
                 <SplitPane
-                  className="BottomSplitPaneContainer"
+                  className="ThreePlotsDiv SplitPanesWrapper"
+                  split="horizontal"
+                  size={horizontalSplitPaneSize}
+                  minSize={185}
+                  maxSize={400}
+                  onDragFinished={size =>
+                    this.splitPaneResized(size, 'horizontal')
+                  }
+                >
+                  {BarcodePlot}
+                  <SplitPane
+                    className="BottomSplitPaneContainer"
+                    split="vertical"
+                    size={this.state.verticalSplitPaneSize}
+                    minSize={315}
+                    maxSize={1300}
+                    onDragFinished={size =>
+                      this.splitPaneResized(size, 'vertical')
+                    }
+                  >
+                    <div id="ViolinAndTableSplitContainer">
+                      {ViolinAndTable}
+                    </div>
+                    <div id="SVGSplitContainer">
+                      <EnrichmentSVGPlot
+                        divWidth={width - verticalSplitPaneSize - 300}
+                        divHeight={height - horizontalSplitPaneSize - 51}
+                        pxToPtRatio={105}
+                        pointSize={12}
+                        svgTabMax={1}
+                        tab={this.props.tab}
+                        plotDataEnrichment={this.props.plotDataEnrichment}
+                        plotDataEnrichmentLength={
+                          this.props.plotDataEnrichmentLength
+                        }
+                        svgExportName={this.props.svgExportName}
+                        enrichmentPlotTypes={this.props.enrichmentPlotTypes}
+                        // isEnrichmentPlotSVGLoaded={this.props.isEnrichmentPlotSVGLoaded}
+                        SVGPlotLoaded={this.props.SVGPlotLoaded}
+                        SVGPlotLoading={this.props.SVGPlotLoading}
+                        HighlightedProteins={this.props.HighlightedProteins}
+                        enrichmentStudy={enrichmentStudy}
+                        enrichmentModel={enrichmentModel}
+                      />
+                    </div>
+                  </SplitPane>
+                </SplitPane>
+              </Grid.Column>
+            </Grid.Row>
+          </Grid>
+        </div>
+      );
+    } else
+      return (
+        <div className="PlotsWrapper">
+          <Grid className="">
+            <Grid.Row className="ActionsRow">
+              <Grid.Column
+                mobile={16}
+                tablet={16}
+                computer={8}
+                largeScreen={8}
+                widescreen={8}
+              >
+                <EnrichmentBreadcrumbs {...this.props} />
+              </Grid.Column>
+              <Grid.Column
+                mobile={16}
+                tablet={16}
+                computer={8}
+                largeScreen={8}
+                widescreen={8}
+                className="elementTextCol"
+              ></Grid.Column>
+
+              <Grid.Column
+                mobile={16}
+                tablet={16}
+                largeScreen={16}
+                widescreen={16}
+              >
+                <SplitPane
+                  className="ThreePlotsDiv SplitPanesWrapper"
                   split="vertical"
                   size={this.state.verticalSplitPaneSize}
                   minSize={315}
@@ -283,7 +355,7 @@ class SplitPanesContainer extends Component {
                   <div id="SVGSplitContainer">
                     <EnrichmentSVGPlot
                       divWidth={width - verticalSplitPaneSize - 300}
-                      divHeight={height - horizontalSplitPaneSize - 51}
+                      divHeight={height - 51}
                       pxToPtRatio={105}
                       pointSize={12}
                       svgTabMax={1}
@@ -303,12 +375,11 @@ class SplitPanesContainer extends Component {
                     />
                   </div>
                 </SplitPane>
-              </SplitPane>
-            </Grid.Column>
-          </Grid.Row>
-        </Grid>
-      </div>
-    );
+              </Grid.Column>
+            </Grid.Row>
+          </Grid>
+        </div>
+      );
   }
 }
 

--- a/src/components/Enrichment/SplitPanesContainer.scss
+++ b/src/components/Enrichment/SplitPanesContainer.scss
@@ -163,7 +163,7 @@
 
   @media (min-width: 1599px) {
     .export-violin {
-      margin: 4px 6px 2px 0px !important;
+      margin: 4px 26px 2px 0px !important;
     }
   }
 

--- a/src/services/omicNavigator.service.js
+++ b/src/services/omicNavigator.service.js
@@ -319,12 +319,20 @@ class OmicNavigatorService {
     }
   }
 
-  async getResultsTable(study, modelID, testID, errorCb, cancelToken) {
-    const cacheKey = `getResultsTable_${study}_${modelID}_${testID}`;
+  async getResultsTable(
+    study,
+    modelID,
+    testID,
+    annotationID,
+    termID,
+    errorCb,
+    cancelToken,
+  ) {
+    const cacheKey = `getResultsTable_${study}_${modelID}_${testID}_${annotationID}_${termID}`;
     if (this[cacheKey] != null) {
       return this[cacheKey];
     } else {
-      const obj = { study, modelID, testID };
+      const obj = { study, modelID, testID, annotationID, termID };
       const promise = this.axiosPost(
         'getResultsTable',
         obj,


### PR DESCRIPTION
Adjusts logic so that studies without barcode data will still display statistics table and SVG plots.  
The statistics table used to be a subset of the getResultsTable and getBarcodeData.  However, with getResultsTable updated to take optional arguments (annotationID, termID), we can just use those results to display the statistics table.

To test, try studies both with barcode data (RNAseq123, and without (`enrichment/D07282022.D20210927.W210488.Hs.Human.skin.LCM/VisiumHS`)

I've merged this to DEV .173 for convenient review.

<img width="1775" alt="no-barcode-data" src="https://user-images.githubusercontent.com/10191004/205362633-07cb0b11-cc6e-452c-8d8c-38ac9810bcea.png">