### PR TITLE
[IPAD-426] Adjust modelID argument for multiModel plotStudy calls

### DIFF
--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -646,8 +646,8 @@ class Differential extends Component {
               differentialTestIds,
               differentialTest,
               differentialModelsAndTests,
-              multiModelMappingFirstKey,
-              // differentialModel,
+              // multiModelMappingFirstKey,
+              differentialModel,
               multiModelMappingArrays,
               id,
             );
@@ -756,8 +756,8 @@ class Differential extends Component {
                 differentialTestIds,
                 differentialTest,
                 differentialModelsAndTests,
-                multiModelMappingFirstKey,
-                // differentialModel,
+                // multiModelMappingFirstKey,
+                differentialModel,
                 multiModelMappingArrays,
                 id,
               );

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -559,8 +559,8 @@ export function getIdArg(
   differentialTestIds,
   differentialTest,
   differentialModelsAndTests,
-  multiModelMappingFirstKey,
-  // differentialModel,
+  // multiModelMappingFirstKey,
+  differentialModel,
   multiModelMappingArrays,
   id,
 ) {
@@ -571,14 +571,15 @@ export function getIdArg(
     // if plot type includes 'multiModel', use the id matched in first in the mapping object
     let mappingId = id;
     const firstMappingModelIndex = differentialModelsAndTests.findIndex(
-      a => a.modelID === multiModelMappingFirstKey,
+      // a => a.modelID === multiModelMappingFirstKey,
+      a => a.modelID === differentialModel,
     );
     const isNotMappingId = firstMappingModelIndex > 0;
     if (isNotMappingId) {
       const idMappingObject = multiModelMappingArrays.filter(m =>
         Object.values(m).includes(id),
       );
-      mappingId = idMappingObject[0]?.[multiModelMappingFirstKey] || id;
+      mappingId = idMappingObject[0]?.[differentialModel] || id;
     }
     return mappingId;
   }
@@ -591,7 +592,7 @@ export function getTestsArg(
   differentialTest,
   differentialModelsAndTests,
   multiModelMappingFirstKey,
-  // differentialModel,
+  differentialModel,
 ) {
   // if plot type does not include 'multiTest', return just the test
   if (!plotType.includes('multiTest')) {
@@ -604,8 +605,8 @@ export function getTestsArg(
       // if plot type includes 'multiTest' AND 'multiModel'
       let tests = [];
       const firstMappingModelIndex = differentialModelsAndTests.findIndex(
-        a => a.modelID === multiModelMappingFirstKey,
-        // a => a.modelID === differentialModel,
+        // a => a.modelID === multiModelMappingFirstKey,
+        a => a.modelID === differentialModel,
       );
       // move the first mapping object models first
       const adjustedArr =
@@ -630,7 +631,6 @@ export function getModelsArg(
   differentialModel,
   differentialModelsAndTests,
   multiModelMappingFirstKey,
-  // differentialModel
   multiModelMappingArrays,
 ) {
   // if plotType does not include 'multiModel', return the model
@@ -640,8 +640,8 @@ export function getModelsArg(
     // if plot type includes 'multiModel'
     let models = [];
     const firstMappingModelIndex = differentialModelsAndTests.findIndex(
-      a => a.modelID === multiModelMappingFirstKey,
-      // a => a.modelID === differentialModel,
+      // a => a.modelID === multiModelMappingFirstKey,
+      a => a.modelID === differentialModel,
     );
     // move the first mapping object models first
     const adjustedArr =


### PR DESCRIPTION
For `plotStudy` multiModel plots, adjust the "modelID" argument to place the model that is **currently selected** in the dropdown to the front of the array, rather than the model that is in the first index of the plotting object.  For example, if a study has 3 tests and the currently selected model is "Transcriptomics", the modelID argument should be `["Transcriptomics","Transcriptomics","Transcriptomics","Proteomics","Proteomics","Proteomics"]` rather than `["Proteomics","Proteomics","Proteomics","Transcriptomics","Transcriptomics","Transcriptomics"]`.

Please test the two studies with multi-model plots: 
1. differential/hiPSCmicrogliaWS4.1toN/transcriptomics
2. differential/W210229.CD40.B6.Mouse.Colon.Multiomics
<img width="1785" alt="multiModel_adjustment" src="https://user-images.githubusercontent.com/10191004/207429482-8773b619-54cc-453d-96cf-d274296226ac.png">
<img width="1787" alt="pro" src="https://user-images.githubusercontent.com/10191004/207429494-f4d57f85-67d9-4880-8520-fd537233d4ca.png">



