### PR TITLE
Multi-feature search v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.7.6",
+      "version": "1.7.7",
       "dependencies": {
         "@observablehq/stdlib": "^3.3.0",
         "airbnb-prop-types": "^2.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "private": true,
   "dependencies": {
     "@observablehq/stdlib": "^3.3.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -408,6 +408,11 @@
   color: var(--color-primary) !important;
 }
 
+.LinkBackground {
+  background-color: var(--color-link) !important;
+  color: var(--color-white) !important;
+}
+
 .FakeDisabled {
   cursor: default;
   opacity: 0.45 !important;

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -1250,6 +1250,7 @@ class DifferentialDetail extends Component {
   handleMultiSearchClear = () => {
     this.setState({
       multiFeatureSearchText: '',
+      multiFeatureSearchActive: true,
     });
   };
 

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -1625,7 +1625,12 @@ class DifferentialDetail extends Component {
       color: '#FFF',
       padding: '1em',
       maxWidth: '50vw',
-      fontSize: '13px',
+      fontSize: '12px',
+      wordBreak: 'break-all',
+    };
+    const SearchPopupMinimalStyle = {
+      maxWidth: '25vw',
+      fontSize: '12px',
       wordBreak: 'break-all',
     };
     const notFoundLength = multiFeaturesNotFound.length;
@@ -1646,12 +1651,10 @@ class DifferentialDetail extends Component {
             ...{notFoundLength - notFoundLimit} more
           </span>
         }
-        style={SearchPopupStyle}
+        style={SearchPopupMinimalStyle}
         className="TablePopupValue"
         content={notFoundAdditional.toString().replace(/,/g, ', ')}
-        // inverted
-        // basic
-        position="right center"
+        position="bottom center"
       />
     ) : null;
 
@@ -1670,16 +1673,14 @@ class DifferentialDetail extends Component {
     const limitFilteredOutText = limitFilteredOut ? (
       <Popup
         trigger={
-          <span id="LimitfilteredOutText">
+          <span id="LimitFilteredOutText">
             ...{filteredOutLength - filteredOutLimit} more
           </span>
         }
-        // style={SearchPopupStyle}
-        // className="TablePopupValue"
+        style={SearchPopupMinimalStyle}
+        className="TablePopupValue"
         content={filteredOutAdditional.toString().replace(/,/g, ', ')}
-        // inverted
-        // basic
-        position="right center"
+        position="bottom center"
       />
     ) : null;
     const multiSearchInput = (

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -1284,13 +1284,26 @@ class DifferentialDetail extends Component {
       differentialAlphanumericFields,
       differentialResultsUnfiltered,
     } = this.props;
-    const { allDataInScatterView, multiFeatureSearchText } = this.state;
+    const {
+      allDataInScatterView,
+      multiFeatureSearchText,
+      multiFeaturesFilteredOut,
+    } = this.state;
     const multiFeatureSearchTextSplit = multiFeatureSearchText
       // split by comma or whitespace (\s), trim and filter out empty strings
       .split(/[,\s]+/)
       .map(item => item.trim())
       .filter(Boolean);
-    const multiFeatureSearchTextSet = new Set(multiFeatureSearchTextSplit);
+    const multiFeatureSearchTextAndFilteredOut = [
+      ...multiFeatureSearchTextSplit,
+      ...multiFeaturesFilteredOut,
+    ];
+    const uniqueMultiFeatureSearchTextAndFilteredOut = [
+      ...new Set(multiFeatureSearchTextAndFilteredOut),
+    ];
+    const multiFeatureSearchTextSet = new Set(
+      uniqueMultiFeatureSearchTextAndFilteredOut,
+    );
     // goal: set the new state for differentialTableData, which will update the scatter plot accordingly
     // 1) Set the "NOT FOUND" data
     let multiFeaturesUnfilteredFound = [];
@@ -1620,10 +1633,26 @@ class DifferentialDetail extends Component {
     const notFoundList = limitNotFound
       ? [...multiFeaturesNotFound].slice(0, notFoundLimit)
       : [...multiFeaturesNotFound];
+    const notFoundAdditional = limitNotFound
+      ? [...multiFeaturesNotFound].slice(
+          notFoundLimit,
+          multiFeaturesNotFound.length,
+        )
+      : [];
     const limitNotFoundText = limitNotFound ? (
-      <span id="LimitNotFoundText">
-        ...{notFoundLength - notFoundLimit} more
-      </span>
+      <Popup
+        trigger={
+          <span id="LimitNotFoundText">
+            ...{notFoundLength - notFoundLimit} more
+          </span>
+        }
+        style={SearchPopupStyle}
+        className="TablePopupValue"
+        content={notFoundAdditional.toString().replace(/,/g, ', ')}
+        // inverted
+        // basic
+        position="right center"
+      />
     ) : null;
 
     const filteredOutLength = multiFeaturesFilteredOut.length;
@@ -1632,10 +1661,26 @@ class DifferentialDetail extends Component {
     const filteredOutList = limitFilteredOut
       ? [...multiFeaturesFilteredOut].slice(0, filteredOutLimit)
       : [...multiFeaturesFilteredOut];
+    const filteredOutAdditional = limitFilteredOut
+      ? [...multiFeaturesFilteredOut].slice(
+          filteredOutLimit,
+          multiFeaturesFilteredOut.length,
+        )
+      : [];
     const limitFilteredOutText = limitFilteredOut ? (
-      <span id="LimitfilteredOutText">
-        ...{filteredOutLength - filteredOutLimit} more
-      </span>
+      <Popup
+        trigger={
+          <span id="LimitfilteredOutText">
+            ...{filteredOutLength - filteredOutLimit} more
+          </span>
+        }
+        // style={SearchPopupStyle}
+        // className="TablePopupValue"
+        content={filteredOutAdditional.toString().replace(/,/g, ', ')}
+        // inverted
+        // basic
+        position="right center"
+      />
     ) : null;
     const multiSearchInput = (
       // this.state.multiSearching ? (

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -1423,6 +1423,7 @@ class DifferentialDetail extends Component {
       singleFeatureSearchText,
       // singleFeatureSearchIcon,
       multiSearching,
+      multiFeaturesSearched,
       multiFeatureSearchText,
       multiFeatureSearchTextError,
       multiFeatureSearchOpen,
@@ -1694,7 +1695,23 @@ class DifferentialDetail extends Component {
             <Popup
               closeOnDocumentClick
               closeOnEscape
-              onClose={() => this.setState({ multiFeatureSearchOpen: false })}
+              onClose={() => {
+                const setSingleSearch =
+                  !multiFeaturesSearched.length && multiFeatureSearchText === ''
+                    ? true
+                    : false;
+                if (setSingleSearch) {
+                  // if user closes popup without search or textarea
+                  this.setState({
+                    multiSearching: false,
+                    multiFeaturesNotFound: [],
+                    multiFeaturesFilteredOut: [],
+                    multiFeatureSearchActive: false,
+                    multiFeatureSearchTextError: false,
+                  });
+                }
+                this.setState({ multiFeatureSearchOpen: false });
+              }}
               trigger={
                 <Button
                   as="div"

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -5,7 +5,7 @@ import CustomEmptyMessage from '../Shared/Templates';
 import { EZGrid } from '../Shared/QHGrid/index.module.js';
 import PlotsOverlay from './PlotsOverlay';
 import PlotsDynamic from './PlotsDynamic';
-import { scrollElement } from '../Shared/helpers';
+import { scrollElement, getDifferenceTwoSets } from '../Shared/helpers';
 import ScatterPlotDiv from './ScatterPlotDiv';
 import {
   Grid,
@@ -78,9 +78,11 @@ class DifferentialDetail extends Component {
     multiFeatureSearchOpen: false,
     multiFeaturesSearched: [],
     multiFeaturesNotFound: [],
+    multiFeaturesFilteredOut: [],
     multiFeatureSearchActive: false,
     multiFeatureSearchTextError: false,
     notFoundLimit: 5,
+    filteredOutLimit: 5,
   };
   volcanoPlotFilteredGridRef = React.createRef();
 
@@ -108,6 +110,7 @@ class DifferentialDetail extends Component {
     ) {
       this.setState({
         allDataInScatterView: differentialResultsUnfiltered,
+        multiFeaturesNotFound: [],
       });
     }
     if (prevProps.differentialResults !== differentialResults) {
@@ -122,20 +125,29 @@ class DifferentialDetail extends Component {
       multiFeaturesSearched,
       singleFeatureSearched,
       allDataInScatterView,
+      multiFeaturesFilteredOut,
     } = this.state;
     // GOAL: set the new state for differentialTableData (consumed by EZGrid)
     // which will update itself (filters) and fire 'handleTableChanged'
     // which sets new state for volcanoPlotSelectedDataArr (consumed by scatter plot)
     let relevantSearched = [...differentialResults];
     // 1) keep the differentialResults that pass single or multiple feature SEARCH filters
+    // PAUL - what is this below? the filtered out labels are not staying after a set analysis
+    const multiFeaturesSearchedAndFilteredOut = [
+      ...multiFeaturesFilteredOut,
+      ...multiFeaturesSearched,
+    ];
+    const multiFeaturesSearchedAndFilteredOutSet = new Set(
+      multiFeaturesSearchedAndFilteredOut,
+    );
     if (multiFeaturesSearched.length || singleFeatureSearched.length) {
       if (multiFeaturesSearched.length) {
         relevantSearched = [];
         // multi-search filter
-        const multiFeaturesSearchedSet = new Set(multiFeaturesSearched);
+        // const multiFeaturesSearchedSet = new Set(multiFeaturesSearched);
         differentialAlphanumericFields.forEach(columnKey => {
           const columnIncludes = [...differentialResults].filter(d => {
-            return multiFeaturesSearchedSet.has(d[columnKey]);
+            return multiFeaturesSearchedAndFilteredOutSet.has(d[columnKey]);
           });
           relevantSearched = [...relevantSearched, ...columnIncludes];
         });
@@ -162,9 +174,48 @@ class DifferentialDetail extends Component {
     relevantSearchedAndInScatterView = [...relevantSearched].filter(d =>
       allDataInScatterViewIdsSet.has(d[this.props.differentialFeatureIdKey]),
     );
+    // const relevantSearchedAndInScatterViewSet = new Set(
+    //   relevantSearchedAndInScatterView,
+    // );
     const uniqueRelevantSearchedAndInScatterView = [
       ...new Set(relevantSearchedAndInScatterView),
     ];
+    let uniqueFilteredOutValues = []; // multiFeaturesFilteredOut
+
+    if (multiFeaturesSearched.length) {
+      // reset the multi-feature search 'filtered out' labels
+      // const multiFeaturesSearchedAndFilteredOut = [...multiFeaturesSearched, ...multiFeaturesFilteredOut];
+      let multiFeaturesFound = [];
+      // multi-search filter
+      // change the "filtered out" tags accordingly"
+      // const multiFeaturesSearchedSet = new Set(multiFeaturesSearched);
+      differentialAlphanumericFields.forEach(columnKey => {
+        // eslint-disable-next-line no-unused-vars
+        const columnIncludes = [
+          ...uniqueRelevantSearchedAndInScatterView,
+        ].filter(d => {
+          if (multiFeaturesSearchedAndFilteredOutSet.has(d[columnKey])) {
+            // push the features found to an array
+            // that will be used to calculate the "Not Found" state
+            multiFeaturesFound.push(d[columnKey]);
+            return true;
+          } else return false;
+        });
+      });
+      const multiFeaturesFoundSet = new Set(multiFeaturesFound);
+      const newlyFilteredOutSet = getDifferenceTwoSets(
+        multiFeaturesSearchedAndFilteredOutSet,
+        multiFeaturesFoundSet,
+      );
+      uniqueFilteredOutValues = [...new Set(newlyFilteredOutSet)];
+      this.setState({
+        // PAUL
+        // adjust the not found, and found (new text)
+        multiFeaturesFilteredOut: uniqueFilteredOutValues,
+        multiFeatureSearchText: multiFeaturesFound.toString(),
+        multiFeatureSearchActive: false,
+      });
+    }
 
     this.setState({
       allChecked: false,
@@ -172,7 +223,6 @@ class DifferentialDetail extends Component {
       differentialTableRows:
         uniqueRelevantSearchedAndInScatterView?.length || 0,
       filteredDifferentialTableData: uniqueRelevantSearchedAndInScatterView,
-      multiFeatureSearchActive: true,
     });
   };
 
@@ -190,6 +240,7 @@ class DifferentialDetail extends Component {
         multiFeatureSearchOpen: false,
         multiFeaturesSearched: [],
         multiFeaturesNotFound: [],
+        multiFeaturesFilteredOut: [],
         multiFeatureSearchActive: false,
         multiFeatureSearchTextError: false,
         // data
@@ -267,35 +318,114 @@ class DifferentialDetail extends Component {
       differentialResults,
       differentialAlphanumericFields,
     } = this.props;
-    const { multiFeaturesSearched, singleFeatureSearched } = this.state;
-    // volcanoPlotSelectedDataArrArg is empty
-    // when grey circles are selected
+    const {
+      multiFeaturesSearched,
+      singleFeatureSearched,
+      multiFeaturesFilteredOut,
+    } = this.state;
+
+    // always set
     this.setState({
-      volcanoPlotSelectedDataArr: volcanoPlotSelectedDataArrArg,
       allDataInScatterView,
-      // on scatter brush, make search active
-      // singleFeatureSearchActive: true,
-      // singleFeatureSearchIcon: 'search',
-      multiFeatureSearchActive: true,
+      volcanoPlotSelectedDataArr: volcanoPlotSelectedDataArrArg,
     });
+    const multiFeaturesSearchedAndFilteredOut = [
+      ...multiFeaturesSearched,
+      ...multiFeaturesFilteredOut,
+    ];
+    // We want to "carry over" search terms FILTERED OUT to subsequent zooms
+    const multiFeaturesSearchedAndFilteredOutSet = new Set(
+      multiFeaturesSearchedAndFilteredOut,
+    );
+    if (multiFeaturesSearched.length && !doubleClickEvent) {
+      // on zoom, we want to change the multi-feature search/textarea to display found/not found pills and text
+      const multiFeaturesSearchedSet = new Set(multiFeaturesSearched);
+      let relevantDifferentialData = [];
+      let multiFeaturesFound = [];
+
+      differentialAlphanumericFields.forEach(columnKey => {
+        // filter the differentialResults for "includes" across all alphanumeric columns
+        const columnIncludes = [...volcanoPlotSelectedDataArrArg].filter(d => {
+          if (multiFeaturesSearchedSet.has(d[columnKey])) {
+            // push the features found to an array
+            // that will be used to calculate the "Not Found" state
+            multiFeaturesFound.push(d[columnKey]);
+            return true;
+          } else return false;
+        });
+        relevantDifferentialData = [
+          ...relevantDifferentialData,
+          ...columnIncludes,
+        ];
+      });
+      const multiFeaturesFoundSet = new Set(multiFeaturesFound);
+      // get the difference between the features searched and found
+      const multiFeaturesFilteredOutSet = getDifferenceTwoSets(
+        multiFeaturesSearchedAndFilteredOutSet,
+        multiFeaturesFoundSet,
+      );
+      //const multiFeaturesAndFilteredOutValues = Array.from(multiFeaturesFilteredOutSet);
+      const uniqueMultiFeaturesFilteredOutValues = [
+        ...new Set(multiFeaturesFilteredOutSet),
+      ];
+      const uniqueMultiFeaturesFoundValues = [
+        ...new Set(multiFeaturesFoundSet),
+      ];
+      this.setState({
+        // on scatter brush, make search active
+        // singleFeatureSearchActive: true,
+        // singleFeatureSearchIcon: 'search',
+        multiFeatureSearchActive: false,
+        multiFeaturesSearched: uniqueMultiFeaturesFoundValues,
+        multiFeaturesFilteredOut: uniqueMultiFeaturesFilteredOutValues,
+        // multiFeatureSearchTextError: uniqueMultiFeaturesAndFilteredOutValues.length,
+        multiFeatureSearchText: uniqueMultiFeaturesFoundValues.toString(),
+      });
+    }
     let relevantDifferentialData = [...volcanoPlotSelectedDataArrArg];
     if (doubleClickEvent) {
       // on double click,
       // differentialResults is passed as volcanoPlotSelectedDataArrArg
       // to make it more clear, just use differentialResults below
-      if (multiFeaturesSearched.length || singleFeatureSearched !== '') {
+      if (
+        multiFeaturesSearchedAndFilteredOut.length ||
+        singleFeatureSearched !== ''
+      ) {
         // find the intersection between the searched features, and volcano plot
-        if (multiFeaturesSearched.length) {
-          const multiFeaturesSearchedSet = new Set(multiFeaturesSearched);
+        if (multiFeaturesSearchedAndFilteredOut.length) {
+          const multiFeaturesSearchedAndFilteredOutSet = new Set(
+            multiFeaturesSearchedAndFilteredOut,
+          );
           relevantDifferentialData = [];
-          differentialAlphanumericFields.forEach(column => {
+          const multiFeaturesFound = [];
+          differentialAlphanumericFields.forEach(columnKey => {
             const columnIncludes = [...differentialResults].filter(d => {
-              return multiFeaturesSearchedSet.has(d[column]);
+              if (multiFeaturesSearchedAndFilteredOutSet.has(d[columnKey])) {
+                // push the features found to an array
+                // that will be used to calculate the "Not Found" state
+                multiFeaturesFound.push(d[columnKey]);
+                return true;
+              } else return false;
             });
             relevantDifferentialData = [
               ...relevantDifferentialData,
               ...columnIncludes,
             ];
+          });
+          const multiFeaturesFoundSet = new Set(multiFeaturesFound);
+          const newlyFilteredOutSet = getDifferenceTwoSets(
+            multiFeaturesSearchedAndFilteredOutSet,
+            multiFeaturesFoundSet,
+          );
+          const uniqueFilteredOutValues = [...new Set(newlyFilteredOutSet)];
+          const uniqueFoundValues = [...new Set(multiFeaturesFoundSet)];
+          this.setState({
+            multiFeatureSearchActive: false,
+            multiFeaturesSearched: uniqueFoundValues,
+            multiFeaturesNotFound: [],
+            multiFeaturesFilteredOut: uniqueFilteredOutValues,
+            // multiFeatureSearchTextError: uniqueMultiFeaturesNotFoundValues.length,
+            multiFeatureSearchText: uniqueFoundValues.toString(),
           });
         } else {
           // single search filter
@@ -794,6 +924,10 @@ class DifferentialDetail extends Component {
     let sortedFilteredData =
       this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.getSortedData() ||
       this.props.differentialResults;
+
+    // if multi-feature search is active, re-run it using data above
+    // PAUL
+
     this.setState(
       {
         filteredDifferentialTableData: sortedFilteredData,
@@ -1073,6 +1207,7 @@ class DifferentialDetail extends Component {
       multiFeatureSearchOpen: false,
       multiFeaturesSearched: [],
       multiFeaturesNotFound: [],
+      multiFeaturesFilteredOut: [],
       differentialTableData: emptySearchData,
       differentialTableRows: emptySearchData?.length || 0,
       singleFeatureSearchActive: false,
@@ -1082,15 +1217,54 @@ class DifferentialDetail extends Component {
   };
 
   handleMultiFeatureSearch = () => {
-    const { differentialResults, differentialAlphanumericFields } = this.props;
+    const {
+      differentialResults,
+      differentialAlphanumericFields,
+      differentialResultsUnfiltered,
+    } = this.props;
+    debugger;
     const { allDataInScatterView, multiFeatureSearchText } = this.state;
     const multiFeatureSearchTextSplit = multiFeatureSearchText
       // split by comma or whitespace (\s), trim and filter out empty strings
       .split(/[,\s]+/)
       .map(item => item.trim())
       .filter(Boolean);
+    const multiFeatureSearchTextSet = new Set(multiFeatureSearchTextSplit);
     // goal: set the new state for differentialTableData, which will update the scatter plot accordingly
-    // 1) Keep all of the differentialResults in the current scatter plot view
+    // 1) Set the "NOT FOUND" data
+    let multiFeaturesUnfilteredFound = [];
+    let relevantDifferentialResultsUnfiltered = [];
+    differentialAlphanumericFields.forEach(columnKey => {
+      // filter the differentialResults for "includes" across all alphanumeric columns
+      const columnIncludes = [...differentialResultsUnfiltered].filter(d => {
+        if (multiFeatureSearchTextSet.has(d[columnKey])) {
+          // push the features found to an array
+          // that will be used to calculate the "Not Found" state
+          multiFeaturesUnfilteredFound.push(d[columnKey]);
+          return true;
+        } else return false;
+      });
+      relevantDifferentialResultsUnfiltered = [
+        ...relevantDifferentialResultsUnfiltered,
+        ...columnIncludes,
+      ];
+    });
+    const multiFeaturesUnfilteredFoundSet = new Set(
+      multiFeaturesUnfilteredFound,
+    );
+    // get the difference between the features searched and found
+    const multiFeaturesUnfilteredNotFoundSet = getDifferenceTwoSets(
+      multiFeatureSearchTextSet,
+      multiFeaturesUnfilteredFoundSet,
+    );
+    const uniqueMultiFeaturesNotFoundValues = [
+      ...new Set(multiFeaturesUnfilteredNotFoundSet),
+    ];
+    const multiFeatureSearchTextSetAfterNotFoundRemoved = getDifferenceTwoSets(
+      multiFeatureSearchTextSet,
+      multiFeaturesUnfilteredNotFoundSet,
+    );
+    // 2) Keep all of the differentialResults in the current scatter plot view
     const allDataInScatterViewIdsSet = new Set(
       [...allDataInScatterView].map(
         d => d[this.props.differentialFeatureIdKey],
@@ -1100,18 +1274,17 @@ class DifferentialDetail extends Component {
       allDataInScatterViewIdsSet.has(d[this.props.differentialFeatureIdKey]),
     );
 
-    // 2) keep the "relevantDifferentialResultsInView" that pass MULTIFEATURE SEARCH filters
-    const multiFeatureSearchTextSet = new Set(multiFeatureSearchTextSplit);
-    let multiFeaturesFound = [];
+    // 3) keep the "relevantDifferentialResultsInView" that pass MULTIFEATURE SEARCH filters
+    let multiFeaturesPassingFilters = [];
     let relevantDifferentialResultsInViewAndSearch = [];
     differentialAlphanumericFields.forEach(columnKey => {
       // filter the differentialResults for "includes" across all alphanumeric columns
       const columnIncludes = [...relevantDifferentialResultsInView].filter(
         d => {
-          if (multiFeatureSearchTextSet.has(d[columnKey])) {
+          if (multiFeatureSearchTextSetAfterNotFoundRemoved.has(d[columnKey])) {
             // push the features found to an array
             // that will be used to calculate the "Not Found" state
-            multiFeaturesFound.push(d[columnKey]);
+            multiFeaturesPassingFilters.push(d[columnKey]);
             return true;
           } else return false;
         },
@@ -1121,21 +1294,19 @@ class DifferentialDetail extends Component {
         ...columnIncludes,
       ];
     });
-
-    function getDifference(setA, setB) {
-      return new Set([...setA].filter(element => !setB.has(element)));
-    }
-    const multiFeaturesFoundSet = new Set(multiFeaturesFound);
+    const multiFeaturesPassingFiltersSet = new Set(multiFeaturesPassingFilters);
     // get the difference between the features searched and found
-    const multiFeaturesNotFoundSet = getDifference(
-      multiFeatureSearchTextSet,
-      multiFeaturesFoundSet,
+    const multiFeaturesFilteredOutSet = getDifferenceTwoSets(
+      multiFeatureSearchTextSetAfterNotFoundRemoved,
+      multiFeaturesPassingFiltersSet,
     );
-    // const multiFeaturesNotFoundValues = Array.from(multiFeaturesNotFoundSet);
-    const uniqueMultiFeaturesNotFoundValues = [
-      ...new Set(multiFeaturesNotFoundSet),
+    // const multiFeaturesFilteredOutValues = Array.from(multiFeaturesFilteredOutSet);
+    const uniqueMultiFeaturesFilteredOutValues = [
+      ...new Set(multiFeaturesFilteredOutSet),
     ];
-    const uniqueMultiFeaturesFoundValues = [...new Set(multiFeaturesFoundSet)];
+    const uniqueMultiFeaturesPassingFiltersValues = [
+      ...new Set(multiFeaturesPassingFiltersSet),
+    ];
     const uniqueRelevantDifferentialResultsInViewAndSearch = [
       ...new Set(relevantDifferentialResultsInViewAndSearch),
     ];
@@ -1144,13 +1315,14 @@ class DifferentialDetail extends Component {
       differentialTableData: uniqueRelevantDifferentialResultsInViewAndSearch,
       differentialTableRows:
         uniqueRelevantDifferentialResultsInViewAndSearch?.length || 0,
-      multiFeaturesSearched: uniqueMultiFeaturesFoundValues,
+      multiFeaturesSearched: uniqueMultiFeaturesPassingFiltersValues,
       multiFeaturesNotFound: uniqueMultiFeaturesNotFoundValues,
+      multiFeaturesFilteredOut: uniqueMultiFeaturesFilteredOutValues,
       multiFeatureSearchOpen: uniqueMultiFeaturesNotFoundValues.length
         ? true
         : false,
       multiFeatureSearchTextError: uniqueMultiFeaturesNotFoundValues.length,
-      multiFeatureSearchText: uniqueMultiFeaturesFoundValues.toString(),
+      multiFeatureSearchText: uniqueMultiFeaturesPassingFiltersValues.toString(),
       multiFeatureSearchActive: false,
       singleFeatureSearchActive: false,
       singleFeatureSearchIcon: 'search',
@@ -1189,13 +1361,14 @@ class DifferentialDetail extends Component {
       singleFeatureSearchText,
       // singleFeatureSearchIcon,
       multiSearching,
-      multiFeaturesSearched,
       multiFeatureSearchText,
       multiFeatureSearchTextError,
       multiFeatureSearchOpen,
       multiFeaturesNotFound,
+      multiFeaturesFilteredOut,
       multiFeatureSearchActive,
       notFoundLimit,
+      filteredOutLimit,
       filteredDifferentialTableData,
     } = this.state;
 
@@ -1368,8 +1541,8 @@ class DifferentialDetail extends Component {
     const searchIcon = singleFeatureSearchText.length < 1 ? 'search' : 'remove';
     const featuresFoundText =
       filteredDifferentialTableData.length === 1 ? 'FEATURE' : 'FEATURES';
-    const termsSearchText =
-      multiFeaturesSearched.length === 1 ? 'TERM' : 'TERMS';
+    // const termsSearchText =
+    //   multiFeaturesSearched.length === 1 ? 'TERM' : 'TERMS';
     const SearchPopupStyle = {
       backgroundColor: '2E2E2E',
       borderBottom: '2px solid var(--color-primary)',
@@ -1387,6 +1560,18 @@ class DifferentialDetail extends Component {
     const limitNotFoundText = limitNotFound ? (
       <span id="LimitNotFoundText">
         ...{notFoundLength - notFoundLimit} more
+      </span>
+    ) : null;
+
+    const filteredOutLength = multiFeaturesFilteredOut.length;
+    const limitFilteredOut =
+      filteredOutLength > filteredOutLimit ? true : false;
+    const filteredOutList = limitFilteredOut
+      ? [...multiFeaturesFilteredOut].slice(0, filteredOutLimit)
+      : [...multiFeaturesFilteredOut];
+    const limitFilteredOutText = limitFilteredOut ? (
+      <span id="LimitfilteredOutText">
+        ...{filteredOutLength - filteredOutLimit} more
       </span>
     ) : null;
     const multiSearchInput = (
@@ -1451,17 +1636,13 @@ class DifferentialDetail extends Component {
               trigger={
                 <Button
                   as="div"
-                  size="small"
                   labelPosition="right"
                   onClick={() => toggleMultiFeatureSearch()}
                 >
-                  <Label as="a" image>
+                  <Button color="blue" size="small">
                     {filteredDifferentialTableData.length} {featuresFoundText}{' '}
-                    FOUND
-                    <Label.Detail id="MultiFeatureSearchTermsLabel">
-                      {multiFeaturesSearched.length} {termsSearchText} SEARCHED
-                    </Label.Detail>
-                  </Label>
+                    {/* FOUND */}
+                  </Button>
                   <Label
                     as="a"
                     basic
@@ -1476,6 +1657,33 @@ class DifferentialDetail extends Component {
                     <Icon name="remove" />
                   </Label>
                 </Button>
+                // <Button
+                //   as="div"
+                //   size="small"
+                //   labelPosition="right"
+                //   onClick={() => toggleMultiFeatureSearch()}
+                // >
+                //   <Label as="a" image>
+                //     {filteredDifferentialTableData.length} {featuresFoundText}{' '}
+                //     FOUND
+                //     <Label.Detail id="MultiFeatureSearchTermsLabel">
+                //       {multiFeaturesSearched.length} {termsSearchText} SEARCHED
+                //     </Label.Detail>
+                //   </Label>
+                //   <Label
+                //     as="a"
+                //     basic
+                //     color="blue"
+                //     pointing="left"
+                //     onClick={e => {
+                //       e.stopPropagation();
+                //       this.handleMultiSearchCancel();
+                //     }}
+                //     id="ClearMultiFeatureSearchLabel"
+                //   >
+                //     <Icon name="remove" />
+                //   </Label>
+                // </Button>
               }
               position="right center"
               basic
@@ -1502,7 +1710,7 @@ class DifferentialDetail extends Component {
                     horizontal
                     size="mini"
                   >
-                    <List.Item className="NoSelect">NOT FOUND:</List.Item>
+                    <List.Item className="NoSelect">DOESN'T EXIST:</List.Item>
                     {notFoundList.map(f => {
                       return (
                         <List.Item key={`featureList-${f}`}>
@@ -1511,6 +1719,33 @@ class DifferentialDetail extends Component {
                       );
                     })}
                     {limitNotFoundText}
+                  </List>
+                ) : null}
+              </Popup.Content>
+              <Popup.Content id="MultiFeaturesSearchedList">
+                {multiFeaturesFilteredOut?.length ? (
+                  <List
+                    animated
+                    inverted
+                    verticalAlign="middle"
+                    className="NoSelect"
+                    divided
+                    horizontal
+                    size="mini"
+                  >
+                    <List.Item className="NoSelect">FILTERED OUT:</List.Item>
+                    {filteredOutList.map(f => {
+                      return (
+                        <List.Item key={`featureList-${f}`}>
+                          <Label
+                          // className="LinkBackground"
+                          >
+                            {f}
+                          </Label>
+                        </List.Item>
+                      );
+                    })}
+                    {limitFilteredOutText}
                   </List>
                 ) : null}
               </Popup.Content>

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -1195,6 +1195,7 @@ class DifferentialDetail extends Component {
       multiFeaturesNotFound,
       multiFeatureSearchActive,
       notFoundLimit,
+      filteredDifferentialTableData,
     } = this.state;
 
     const {
@@ -1364,8 +1365,10 @@ class DifferentialDetail extends Component {
 
     const searchColor = singleFeatureSearchText.length < 1 ? null : 'blue';
     const searchIcon = singleFeatureSearchText.length < 1 ? 'search' : 'remove';
-    const featuresText =
-      multiFeaturesSearched.length === 1 ? 'FEATURE' : 'FEATURES';
+    const featuresFoundText =
+      filteredDifferentialTableData.length === 1 ? 'FEATURE' : 'FEATURES';
+    const termsSearchText =
+      multiFeaturesSearched.length === 1 ? 'TERM' : 'TERMS';
     const SearchPopupStyle = {
       backgroundColor: '2E2E2E',
       borderBottom: '2px solid var(--color-primary)',
@@ -1397,6 +1400,7 @@ class DifferentialDetail extends Component {
                 className={
                   singleFeatureSearchText.length ? 'FakeDisabled' : null
                 }
+                size="small"
                 icon
                 id="MultiFeatureSearchToggle"
                 onClick={() => {
@@ -1446,12 +1450,17 @@ class DifferentialDetail extends Component {
               trigger={
                 <Button
                   as="div"
+                  size="small"
                   labelPosition="right"
                   onClick={() => toggleMultiFeatureSearch()}
                 >
-                  <Button color="blue" size="small">
-                    {multiFeaturesSearched.length} {featuresText} FOUND
-                  </Button>
+                  <Label as="a" image>
+                    {filteredDifferentialTableData.length} {featuresFoundText}{' '}
+                    FOUND
+                    <Label.Detail id="MultiFeatureSearchTermsLabel">
+                      {multiFeaturesSearched.length} {termsSearchText} SEARCHED
+                    </Label.Detail>
+                  </Label>
                   <Label
                     as="a"
                     basic
@@ -1508,7 +1517,7 @@ class DifferentialDetail extends Component {
                 <Form>
                   <Form.TextArea
                     autoFocus
-                    placeholder="Separate featurs with a comma, space, or newline (NOTE: This is an exact search)"
+                    placeholder="Separate features with a comma, space, or newline (NOTE: This is an exact search)"
                     name="multiFeatureSearchText"
                     id="multiFeatureSearchTextArea"
                     value={multiFeatureSearchText}

--- a/src/components/Differential/DifferentialDetail.scss
+++ b/src/components/Differential/DifferentialDetail.scss
@@ -353,6 +353,11 @@
   color: var(--color-primary);
 }
 
+#multiFeatureSearchWarning {
+  margin: 10px 0 !important;
+  // color: var(--color-primary);
+}
+
 #MultiFeaturesSearchedList {
   margin: 10px 0 5px 0;
 }

--- a/src/components/Differential/DifferentialDetail.scss
+++ b/src/components/Differential/DifferentialDetail.scss
@@ -370,7 +370,8 @@
   margin-left: 5px;
 }
 
-#LimitNotFoundText {
+#LimitNotFoundText,
+#LimitFilteredOutText {
   font-size: 14px;
 }
 

--- a/src/components/Differential/DifferentialDetail.scss
+++ b/src/components/Differential/DifferentialDetail.scss
@@ -345,7 +345,7 @@
 
 #MultiFeatureSearchPopup {
   top: 61px !important;
-  left: -235px !important;
+  left: -375px !important;
 }
 
 #multiFeatureSearchTextError {
@@ -372,4 +372,10 @@
 
 #LimitNotFoundText {
   font-size: 14px;
+}
+
+#MultiFeatureSearchTermsLabel {
+  background-color: #2185d0;
+  color: white;
+  border-radius: 0;
 }

--- a/src/components/Differential/DifferentialDetail.scss
+++ b/src/components/Differential/DifferentialDetail.scss
@@ -345,7 +345,7 @@
 
 #MultiFeatureSearchPopup {
   top: 61px !important;
-  left: -375px !important;
+  left: -235px !important;
 }
 
 #multiFeatureSearchTextError {

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -661,3 +661,8 @@ export function getModelsArg(
     return models;
   }
 }
+
+// helper function to get the difference between two sets
+export function getDifferenceTwoSets(setA, setB) {
+  return new Set([...setA].filter(element => !setB.has(element)));
+}

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.7.6',
+      appVersion: '1.7.7',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
- Changes "Not Found" to "Doesn't Exist", and adds another category of labels, "Filtered Out"
- Original search is retained in state, and the multi-feature search popup re-renders "Filtered Out" and search text after a change in 1) set analysis, 2) scatter plot zoom in/out 3) table column filter change.  For example, If 5 terms are initially searched, after any of the above 3 actions, the popup will adjust accordingly with those 5 terms in mind, until another search occurs, or the search is cancelled.
- "Filtered Out" state retains/updates accordingly with what was included on the previously search, and only clears when the search is "cancelled"
- Adds a warning/decision when closing the popup in various situations