### PR TITLE
[IPAD-435] Retain table row order after scatterplot zoom

### DIFF
--- a/src/components/Differential/ScatterPlot.jsx
+++ b/src/components/Differential/ScatterPlot.jsx
@@ -1527,7 +1527,13 @@ class ScatterPlot extends Component {
               transitioningBoxSelect: true,
               zoomedOut: false,
             });
-            self.transitionZoom(total, false, false, true);
+            const totalSet = new Set(
+              [...total].map(d => d[self.props.differentialFeatureIdKey]),
+            );
+            const intersection2 = [
+              ...self.props.filteredDifferentialTableData,
+            ].filter(d => totalSet.has(d[self.props.differentialFeatureIdKey]));
+            self.transitionZoom(intersection2, false, false, true);
             self.setupBrush(
               self.props.volcanoWidth,
               self.props.upperPlotsHeight,


### PR DESCRIPTION
Problem: when zooming in the scatterplot **with a section containing a hexbin**, the table rows are reordered. It would be ideal if the default table sorting was maintained.

Solution: on zoom, take the existing table data and filter it by the new zoomed data, rather than just passing the new zoomed data, which has it's own, different order it recalculates if a hexbin is unbinned.

To test: DO A HARD REFRESH.  go to [prod](http://omicnavigator.ir-omicnavigator.awscloud.abbvienet.com/ocpu/library/OmicNavigator/www/#/differential/RNAseq123/Differential_Expression/BasalvsLP), set table 'items per page' to 10, notice the order of the table, and how it changes when a section including a hexbin is zoomed.  Note, you Next, go to [dev](http://10.253.152.173/ocpu/library/OmicNavigator/www/#/differential/RNAseq123/Differential_Expression/BasalvsLP) (where this is merged), and do the same thing, and see how the order is maintained.

