### PR TITLE
[IPAD-441] Extent NA message to non-plotly plots

### DIFF
--- a/src/components/Differential/TabMultiFeature.jsx
+++ b/src/components/Differential/TabMultiFeature.jsx
@@ -90,7 +90,7 @@ class TabMultiFeature extends Component {
                       featuresLength={featuresLength}
                       onHandlePlotlyClick={this.props.onHandlePlotlyClick}
                     />
-                  ) : (
+                  ) : s.svg ? (
                     <SVG
                       cacheRequests={true}
                       src={srcUrl}
@@ -98,6 +98,13 @@ class TabMultiFeature extends Component {
                       uniqueHash={`b2g9e2-${cacheStringArg}`}
                       uniquifyIDs={true}
                     />
+                  ) : (
+                    <div className="PlotInstructions">
+                      <h4 className="PlotInstructionsText NoSelect">
+                        {s.plotType.plotDisplay} is not available for this
+                        combination of features
+                      </h4>
+                    </div>
                   )}
                 </div>
               </Tab.Pane>

--- a/src/components/Differential/TabSingleFeature.jsx
+++ b/src/components/Differential/TabSingleFeature.jsx
@@ -91,7 +91,7 @@ class TabSingleFeature extends Component {
                       this.props.differentialDetailPlotsSingleFeatureRefFwd
                     }
                   />
-                ) : (
+                ) : s.svg ? (
                   <SVG
                     cacheRequests={true}
                     src={srcUrl}
@@ -99,6 +99,13 @@ class TabSingleFeature extends Component {
                     uniqueHash={`a1f8d1-${cacheStringArg}`}
                     uniquifyIDs={true}
                   />
+                ) : (
+                  <div className="PlotInstructions">
+                    <h4 className="PlotInstructionsText NoSelect">
+                      {s.plotType.plotDisplay} is not available for feature{' '}
+                      {plotSingleFeatureData.key}
+                    </h4>
+                  </div>
                 )}
               </div>
             </Tab.Pane>

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -2495,7 +2495,7 @@ class Enrichment extends Component {
           </Grid.Row>
         </Grid>
         <div className="MultisetSvgOuter" id="enrichmentMultisetAnalysisSVGDiv">
-          {multisetPlotInfoEnrichment.svg?.length ? (
+          {multisetPlotInfoEnrichment.svg ? (
             <SVG
               cacheRequests={true}
               src={srcUrl}
@@ -2503,7 +2503,14 @@ class Enrichment extends Component {
               uniquifyIDs={true}
               id="enrichmentMultisetAnalysisSVG"
             />
-          ) : null}
+          ) : (
+            <div className="PlotInstructions">
+              <h4 className="PlotInstructionsText NoSelect">
+                {multisetPlotInfoEnrichment.title} is not available for this
+                combination of features
+              </h4>
+            </div>
+          )}
         </div>
       </Sidebar>
     );

--- a/src/components/Enrichment/EnrichmentSVGPlot.jsx
+++ b/src/components/Enrichment/EnrichmentSVGPlot.jsx
@@ -109,7 +109,7 @@ class EnrichmentSVGPlot extends PureComponent {
                     plotId={plotDataEnrichment?.key}
                     parentNode={this.enrichmentSingleFeatureRef}
                   />
-                ) : (
+                ) : s.svg ? (
                   <SVG
                     cacheRequests={true}
                     src={srcUrl}
@@ -117,6 +117,13 @@ class EnrichmentSVGPlot extends PureComponent {
                     uniquifyIDs={true}
                     id="EnrichmentPlotSVG"
                   />
+                ) : (
+                  <div className="PlotInstructions">
+                    <h4 className="PlotInstructionsText NoSelect">
+                      {s.plotType.plotDisplay} is not available for{' '}
+                      {plotDataEnrichment?.key}
+                    </h4>
+                  </div>
                 )}
               </div>
             </Tab.Pane>


### PR DESCRIPTION
Currently only "plotly" plots are displaying a message in the UI informing users a given plot isn't available.  Extend this message to all other plot types.

