### PR TITLE
[IPAD-439] Adjust modelIDs argument order

### DIFF
--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -668,12 +668,21 @@ export function getModelsArg(
       // repeated n times,
       // where n is the number of tests present under the currently selected model
       let models = [];
-      const currentModelAndTests = [...differentialModelsAndTests].find(
-        a => a.modelID === differentialModel,
-      );
-      currentModelAndTests.tests.forEach(() => {
-        orderedDifferentialModelIds.forEach(modelId => {
-          models.push(modelId);
+      const currentDifferentialModelsAndTestsIndex = [
+        ...differentialModelsAndTests,
+      ].findIndex(a => a.modelID === differentialModel);
+      // move the first mapping object models first
+      const currentDifferentialModelsAndTestsMoved =
+        currentDifferentialModelsAndTestsIndex > 0
+          ? arrayMove(
+              differentialModelsAndTests,
+              currentDifferentialModelsAndTestsIndex,
+              0,
+            )
+          : differentialModelsAndTests;
+      currentDifferentialModelsAndTestsMoved.forEach(cdmtm => {
+        cdmtm.tests.forEach(test => {
+          models.push(cdmtm.modelID);
         });
       });
       return models;


### PR DESCRIPTION
I mentioned previously the front-end is ensuring that “the modelID argument must have the currently selected model in the first index of the vector”, so say, when the currently selected model is “transcriptomics”, part of the payload was sent like this: modelID: ["transcriptomics", "proteomics", "transcriptomics", "proteomics", "transcriptomics", "proteomics", "transcriptomics", "proteomics”], testID: ["E2E2_E3E3", "KO_E3E3", "E4E4_E3E3", "E3E4_E3E3", "E2E2_E3E3", "KO_E3E3", "E4E4_E3E3", "E3E4_E3E3"] 

This PR is to ensure the order of the vector of model ids match up correctly to each test id. The easiest way to accomplish that is to just repeat the first model, then repeat the second model, like this: modelID: ["transcriptomics", "transcriptomics", "transcriptomics", "transcriptomics", "proteomics”, "proteomics”, "proteomics”, "proteomics”].