### PR TITLE
[AU-450] Swap react-split-pane module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react-scripts": "^4.0.3",
         "react-slider": "^2.0.4",
         "react-sortable-hoc": "^2.0.0",
-        "react-split-pane": "^0.1.87",
+        "react-split-pane-r17": "^1.1.0",
         "react-toastify": "^5.5.0",
         "react-virtualized": "^9.22.5",
         "regenerator-runtime": "^0.13.11",
@@ -22714,18 +22714,18 @@
         "react-dom": "^16.3.0 || ^17.0.0"
       }
     },
-    "node_modules/react-split-pane": {
-      "version": "0.1.92",
-      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.92.tgz",
-      "integrity": "sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==",
+    "node_modules/react-split-pane-r17": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-split-pane-r17/-/react-split-pane-r17-1.1.0.tgz",
+      "integrity": "sha512-a/obOWBKDQk+F6SjE/E/XNAGVRlFdnTGci/89XCMR8cW67NV1DDjj3DHLbe7Xb15DBsvSzKqRYXROixDs+LYXQ==",
       "dependencies": {
         "prop-types": "^15.7.2",
         "react-lifecycles-compat": "^3.0.4",
         "react-style-proptype": "^3.2.2"
       },
       "peerDependencies": {
-        "react": "^16.0.0-0",
-        "react-dom": "^16.0.0-0"
+        "react": "^17.0.0-0",
+        "react-dom": "^17.0.0-0"
       }
     },
     "node_modules/react-style-proptype": {
@@ -48294,10 +48294,10 @@
         "prop-types": "^15.5.7"
       }
     },
-    "react-split-pane": {
-      "version": "0.1.92",
-      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.92.tgz",
-      "integrity": "sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==",
+    "react-split-pane-r17": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-split-pane-r17/-/react-split-pane-r17-1.1.0.tgz",
+      "integrity": "sha512-a/obOWBKDQk+F6SjE/E/XNAGVRlFdnTGci/89XCMR8cW67NV1DDjj3DHLbe7Xb15DBsvSzKqRYXROixDs+LYXQ==",
       "requires": {
         "prop-types": "^15.7.2",
         "react-lifecycles-compat": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-scripts": "^4.0.3",
     "react-slider": "^2.0.4",
     "react-sortable-hoc": "^2.0.0",
-    "react-split-pane": "^0.1.87",
+    "react-split-pane-r17": "^1.1.0",
     "react-toastify": "^5.5.0",
     "react-virtualized": "^9.22.5",
     "regenerator-runtime": "^0.13.11",

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -19,7 +19,7 @@ import {
 } from 'semantic-ui-react';
 import ButtonActions from '../Shared/ButtonActions';
 import './DifferentialDetail.scss';
-import SplitPane from 'react-split-pane';
+import SplitPane from 'react-split-pane-r17';
 
 class DifferentialDetail extends Component {
   state = {

--- a/src/components/Enrichment/SplitPanesContainer.jsx
+++ b/src/components/Enrichment/SplitPanesContainer.jsx
@@ -3,7 +3,7 @@ import { withRouter } from 'react-router-dom';
 import { Grid, Dimmer, Loader, Tab } from 'semantic-ui-react';
 import EnrichmentBreadcrumbs from './EnrichmentBreadcrumbs';
 import ButtonActions from '../Shared/ButtonActions';
-import SplitPane from 'react-split-pane';
+import SplitPane from 'react-split-pane-r17';
 import './SplitPanesContainer.scss';
 import EnrichmentSVGPlot from './EnrichmentSVGPlot';
 import BarcodePlot from './BarcodePlot';


### PR DESCRIPTION
react-split-pane is deprecated and when using with React 17 (or 18), throws errors when running the latest versions of npm (higher than 8.5.5). This task swaps it out for [react-split-pane-r17](https://www.npmjs.com/package/react-split-pane-r17), as suggested on this [thread](https://github.com/decaporg/decap-cms/pull/6137). This way we don't need to resort to suggesting _npm install --legacy-peer-deps_