### PR TITLE
[IPAD-458] adjust -log10 transformations, handle infinity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "dependencies": {
         "@observablehq/stdlib": "^5.6.1",
         "array-move": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "private": true,
   "dependencies": {
     "@observablehq/stdlib": "^5.6.1",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom';
 import SVG from 'react-inlinesvg';
 import { toast } from 'react-toastify';
 import {
-  isNotNANullUndefinedEmptyString,
+  isNotNANullUndefinedEmptyStringInf,
   formatNumberForDisplay,
   splitValue,
   Linkout,
@@ -1475,7 +1475,7 @@ class Differential extends Component {
         // loop through data, one property at a time
         const notNullObject = dataCopy.find((row) => {
           // find the first value for that property
-          return isNotNANullUndefinedEmptyString(row[property]);
+          return isNotNANullUndefinedEmptyStringInf(row[property]);
         });
         let notNullValue = null;
         if (notNullObject) {
@@ -1770,7 +1770,8 @@ class Differential extends Component {
     const multiModelMappingObjectCopy = [...multiModelMappingObject];
     const multiModelMappingArrays = multiModelMappingObjectCopy.filter((mm) => {
       return Object.values(mm).every(
-        (x) => x !== 'NA' && x !== '' && x != null,
+        (x) =>
+          x !== 'NA' && x !== '' && x != null && x !== 'Inf' && x !== '-Inf',
       );
     });
     let multiModelMappingObjectArr = [];

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -1900,7 +1900,6 @@ class DifferentialDetail extends Component {
         onHandleVolcanoPlotSelectionChange={
           this.handleVolcanoPlotSelectionChange
         }
-        // getMaxAndMin={this.getMaxAndMin}
         onHandleDotClick={this.handleDotClick}
         onPageToFeature={this.pageToFeature}
         onHandleUpdateDifferentialResults={

--- a/src/components/Differential/MetafeaturesTable.jsx
+++ b/src/components/Differential/MetafeaturesTable.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Popup } from 'semantic-ui-react';
 // import _ from 'lodash-es';
 import {
-  isNotNANullUndefinedEmptyString,
+  isNotNANullUndefinedEmptyStringInf,
   formatNumberForDisplay,
   splitValue,
 } from '../Shared/helpers';
@@ -57,7 +57,7 @@ class MetafeaturesTable extends Component {
     }
   }
 
-  getMetafeaturesTableConfigCols = data => {
+  getMetafeaturesTableConfigCols = (data) => {
     let configCols = [];
     if (data?.length > 0) {
       const TableValuePopupStyle = {
@@ -80,11 +80,11 @@ class MetafeaturesTable extends Component {
       if (firstFullObject) {
         let allProperties = Object.keys(firstFullObject);
         const dataCopy = [...data];
-        allProperties.forEach(property => {
+        allProperties.forEach((property) => {
           // loop through data, one property at a time
-          const notNullObject = dataCopy.find(row => {
+          const notNullObject = dataCopy.find((row) => {
             // find the first value for that property
-            return isNotNANullUndefinedEmptyString(row[property]);
+            return isNotNANullUndefinedEmptyStringInf(row[property]);
           });
           let notNullValue = null;
           if (notNullObject) {
@@ -106,8 +106,8 @@ class MetafeaturesTable extends Component {
         });
       }
 
-      const metafeaturesAlphanumericColumnsMapped = metafeaturesAlphanumericFields.map(
-        f => {
+      const metafeaturesAlphanumericColumnsMapped =
+        metafeaturesAlphanumericFields.map((f) => {
           return {
             title: f,
             field: f,
@@ -127,16 +127,15 @@ class MetafeaturesTable extends Component {
               );
             },
           };
-        },
-      );
+        });
       const metafeaturesNumericColumnsMapped = metafeaturesNumericFields.map(
-        c => {
+        (c) => {
           return {
             title: c,
             field: c,
             type: 'number',
             filterable: { type: 'numericFilter' },
-            exportTemplate: value => (value ? `${value}` : 'N/A'),
+            exportTemplate: (value) => (value ? `${value}` : 'N/A'),
             template: (value, item, addParams) => {
               return (
                 <p>
@@ -169,7 +168,7 @@ class MetafeaturesTable extends Component {
     });
   };
 
-  handleItemsPerPageChange = items => {
+  handleItemsPerPageChange = (items) => {
     this.setState({
       itemsPerPageMetafeaturesTable: items,
     });

--- a/src/components/Differential/MetafeaturesTableDynamic.jsx
+++ b/src/components/Differential/MetafeaturesTableDynamic.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Popup } from 'semantic-ui-react';
 // import _ from 'lodash-es';
 import {
-  isNotNANullUndefinedEmptyString,
+  isNotNANullUndefinedEmptyStringInf,
   formatNumberForDisplay,
   splitValue,
 } from '../Shared/helpers';
@@ -78,7 +78,7 @@ class MetafeaturesTableDynamic extends Component {
     }
   }
 
-  getMetafeaturesTableConfigCols = data => {
+  getMetafeaturesTableConfigCols = (data) => {
     let configCols = [];
     if (data?.length > 0) {
       const TableValuePopupStyle = {
@@ -101,11 +101,11 @@ class MetafeaturesTableDynamic extends Component {
       if (firstFullObject) {
         let allProperties = Object.keys(firstFullObject);
         const dataCopy = [...data];
-        allProperties.forEach(property => {
+        allProperties.forEach((property) => {
           // loop through data, one property at a time
-          const notNullObject = dataCopy.find(row => {
+          const notNullObject = dataCopy.find((row) => {
             // find the first value for that property
-            return isNotNANullUndefinedEmptyString(row[property]);
+            return isNotNANullUndefinedEmptyStringInf(row[property]);
           });
           let notNullValue = null;
           if (notNullObject) {
@@ -126,8 +126,8 @@ class MetafeaturesTableDynamic extends Component {
           }
         });
       }
-      const metafeaturesAlphanumericColumnsMapped = metafeaturesAlphanumericFields.map(
-        f => {
+      const metafeaturesAlphanumericColumnsMapped =
+        metafeaturesAlphanumericFields.map((f) => {
           return {
             title: f,
             field: f,
@@ -147,16 +147,15 @@ class MetafeaturesTableDynamic extends Component {
               );
             },
           };
-        },
-      );
+        });
       const metafeaturesNumericColumnsMapped = metafeaturesNumericFields.map(
-        c => {
+        (c) => {
           return {
             title: c,
             field: c,
             type: 'number',
             filterable: { type: 'numericFilter' },
-            exportTemplate: value => (value ? `${value}` : 'N/A'),
+            exportTemplate: (value) => (value ? `${value}` : 'N/A'),
             template: (value, item, addParams) => {
               return (
                 <p>
@@ -189,7 +188,7 @@ class MetafeaturesTableDynamic extends Component {
     }
   };
 
-  handleItemsPerPageChange = items => {
+  handleItemsPerPageChange = (items) => {
     this.setState({
       itemsPerPageMetafeaturesTable: items,
     });

--- a/src/components/Differential/ScatterPlot.jsx
+++ b/src/components/Differential/ScatterPlot.jsx
@@ -637,11 +637,17 @@ class ScatterPlot extends Component {
   }
 
   scaleFactory(scaleData) {
-    const { volcanoWidth, upperPlotsHeight, xAxisLabel, yAxisLabel } =
-      this.props;
+    const {
+      volcanoWidth,
+      upperPlotsHeight,
+      xAxisLabel,
+      yAxisLabel,
+      doXAxisTransformation,
+      doYAxisTransformation,
+    } = this.props;
 
-    var xMM = getMaxAndMin(scaleData, xAxisLabel);
-    var yMM = getMaxAndMin(scaleData, yAxisLabel);
+    var xMM = getMaxAndMin(scaleData, xAxisLabel, doXAxisTransformation);
+    var yMM = getMaxAndMin(scaleData, yAxisLabel, doYAxisTransformation);
     xMM = [this.doTransform(xMM[0], 'x'), this.doTransform(xMM[1], 'x')];
     yMM = [this.doTransform(yMM[0], 'y'), this.doTransform(yMM[1], 'y')];
 

--- a/src/components/Differential/ScatterPlot.jsx
+++ b/src/components/Differential/ScatterPlot.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import _ from 'lodash-es';
 import * as d3 from 'd3';
 import * as hexbin from 'd3-hexbin';
-import { loadingDimmerGeneric } from '../Shared/helpers';
+import { loadingDimmerGeneric, getMaxAndMin } from '../Shared/helpers';
 import './ScatterPlot.scss';
 
 class ScatterPlot extends Component {
@@ -640,8 +640,8 @@ class ScatterPlot extends Component {
     const { volcanoWidth, upperPlotsHeight, xAxisLabel, yAxisLabel } =
       this.props;
 
-    var xMM = this.getMaxAndMin(scaleData, xAxisLabel);
-    var yMM = this.getMaxAndMin(scaleData, yAxisLabel);
+    var xMM = getMaxAndMin(scaleData, xAxisLabel);
+    var yMM = getMaxAndMin(scaleData, yAxisLabel);
     xMM = [this.doTransform(xMM[0], 'x'), this.doTransform(xMM[1], 'x')];
     yMM = [this.doTransform(yMM[0], 'y'), this.doTransform(yMM[1], 'y')];
 
@@ -1722,30 +1722,6 @@ class ScatterPlot extends Component {
     } else if (upperPlotsHeight > 500) {
       return upperPlotsHeight - 10;
     } else return upperPlotsHeight - 15;
-  }
-
-  getMaxAndMin(data, element) {
-    if (data?.length > 0) {
-      let values = [0, 0];
-      if (data[0][element] != null) {
-        values = [data[0][element], data[0][element]];
-      }
-      for (var i = 1; i < data.length; i++) {
-        if (
-          data[i] != null &&
-          data[i][element] != null &&
-          data[i][element] !== 0
-          // ignore blanks and 0s, but plot positive or negatives
-        ) {
-          if (data[i][element] > values[1]) {
-            values[1] = data[i][element];
-          } else if (data[i][element] < values[0]) {
-            values[0] = data[i][element];
-          }
-        }
-      }
-      return values;
-    } else return [0, 0];
   }
 
   render() {

--- a/src/components/Differential/ScatterPlotDiv.jsx
+++ b/src/components/Differential/ScatterPlotDiv.jsx
@@ -25,15 +25,15 @@ import './ScatterPlotDiv.scss';
 class ScatterPlotDiv extends Component {
   state = {
     doXAxisTransformation:
-      JSON.parse(sessionStorage.getItem('doXAxisTransformation')) === true
-        ? // || sessionStorage.getItem('doXAxisTransformation') == null
-          true
+      JSON.parse(sessionStorage.getItem('doXAxisTransformation')) === true ||
+      sessionStorage.getItem('doXAxisTransformation') == null
+        ? true
         : false,
 
     doYAxisTransformation:
-      JSON.parse(sessionStorage.getItem('doYAxisTransformation')) === true
-        ? // || sessionStorage.getItem('doYAxisTransformation') == null
-          true
+      JSON.parse(sessionStorage.getItem('doYAxisTransformation')) === true ||
+      sessionStorage.getItem('doYAxisTransformation') == null
+        ? true
         : false,
 
     allowXTransformation:
@@ -108,7 +108,7 @@ class ScatterPlotDiv extends Component {
     const { differentialResultsUnfiltered } = this.props;
     if (name === 'xAxisSelector') {
       const allowXTransCheck =
-        getMaxAndMin(differentialResultsUnfiltered, value)[0] > 0;
+        getMaxAndMin(differentialResultsUnfiltered, value)[0] >= 0;
       const doXaxisTransCheck = allowXTransCheck
         ? this.state.doXAxisTransformation
         : false;
@@ -122,7 +122,7 @@ class ScatterPlotDiv extends Component {
       sessionStorage.setItem('allowXTransformation', allowXTransCheck);
     } else if (name === 'yAxisSelector') {
       const allowYTransCheck =
-        getMaxAndMin(differentialResultsUnfiltered, value)[0] > 0;
+        getMaxAndMin(differentialResultsUnfiltered, value)[0] >= 0;
       const doYaxisTransCheck = allowYTransCheck
         ? this.state.doYAxisTransformation
         : false;
@@ -233,7 +233,7 @@ class ScatterPlotDiv extends Component {
     if (xLabel == null) {
       xLabel = getXAxis(relevantConfigColumns);
     }
-    const allowXTransCheck = getMaxAndMin(differentialResults, xLabel)[0] > 0;
+    const allowXTransCheck = getMaxAndMin(differentialResults, xLabel)[0] >= 0;
     const doXaxisTransCheck = allowXTransCheck
       ? this.state.doXAxisTransformation
       : false;
@@ -251,7 +251,7 @@ class ScatterPlotDiv extends Component {
         yLabel = relevantConfigColumns[0];
       }
     }
-    const allowYTransCheck = getMaxAndMin(differentialResults, yLabel)[0] > 0;
+    const allowYTransCheck = getMaxAndMin(differentialResults, yLabel)[0] >= 0;
     const doYaxisTransCheck = allowYTransCheck
       ? this.state.doYAxisTransformation
       : false;

--- a/src/components/Differential/ScatterPlotDiv.jsx
+++ b/src/components/Differential/ScatterPlotDiv.jsx
@@ -14,6 +14,7 @@ import {
 } from 'semantic-ui-react';
 import {
   isNotNANullUndefinedEmptyStringInf,
+  getMaxAndMin,
   getYAxis,
   getXAxis,
 } from '../Shared/helpers';
@@ -103,35 +104,11 @@ class ScatterPlotDiv extends Component {
     }
   }
 
-  getMaxAndMin = (data, element) => {
-    if (data.length > 0) {
-      let values = [0, 0];
-      if (data[0][element] != null) {
-        values = [data[0][element], data[0][element]];
-      }
-      for (var i = 1; i < data.length; i++) {
-        if (
-          data[i] != null &&
-          data[i][element] != null &&
-          data[i][element] !== 0
-          // ignore blanks and 0s, but plot positive or negatives
-        ) {
-          if (data[i][element] > values[1]) {
-            values[1] = data[i][element];
-          } else if (data[i][element] < values[0]) {
-            values[0] = data[i][element];
-          }
-        }
-      }
-      return values;
-    }
-  };
-
   handleDropdownChange = (evt, { name, value }) => {
     const { differentialResultsUnfiltered } = this.props;
     if (name === 'xAxisSelector') {
       const allowXTransCheck =
-        this.getMaxAndMin(differentialResultsUnfiltered, value)[0] > 0;
+        getMaxAndMin(differentialResultsUnfiltered, value)[0] > 0;
       const doXaxisTransCheck = allowXTransCheck
         ? this.state.doXAxisTransformation
         : false;
@@ -145,7 +122,7 @@ class ScatterPlotDiv extends Component {
       sessionStorage.setItem('allowXTransformation', allowXTransCheck);
     } else if (name === 'yAxisSelector') {
       const allowYTransCheck =
-        this.getMaxAndMin(differentialResultsUnfiltered, value)[0] > 0;
+        getMaxAndMin(differentialResultsUnfiltered, value)[0] > 0;
       const doYaxisTransCheck = allowYTransCheck
         ? this.state.doYAxisTransformation
         : false;
@@ -256,8 +233,7 @@ class ScatterPlotDiv extends Component {
     if (xLabel == null) {
       xLabel = getXAxis(relevantConfigColumns);
     }
-    const allowXTransCheck =
-      this.getMaxAndMin(differentialResults, xLabel)[0] > 0;
+    const allowXTransCheck = getMaxAndMin(differentialResults, xLabel)[0] > 0;
     const doXaxisTransCheck = allowXTransCheck
       ? this.state.doXAxisTransformation
       : false;
@@ -275,8 +251,7 @@ class ScatterPlotDiv extends Component {
         yLabel = relevantConfigColumns[0];
       }
     }
-    const allowYTransCheck =
-      this.getMaxAndMin(differentialResults, yLabel)[0] > 0;
+    const allowYTransCheck = getMaxAndMin(differentialResults, yLabel)[0] > 0;
     const doYaxisTransCheck = allowYTransCheck
       ? this.state.doYAxisTransformation
       : false;

--- a/src/components/Differential/ScatterPlotDiv.jsx
+++ b/src/components/Differential/ScatterPlotDiv.jsx
@@ -13,7 +13,7 @@ import {
   List,
 } from 'semantic-ui-react';
 import {
-  isNotNANullUndefinedEmptyString,
+  isNotNANullUndefinedEmptyStringInf,
   getYAxis,
   getXAxis,
 } from '../Shared/helpers';
@@ -203,7 +203,7 @@ class ScatterPlotDiv extends Component {
         // loop through data, one property at a time
         const notNullObject = dataCopy.find((row) => {
           // find the first value for that property
-          return isNotNANullUndefinedEmptyString(row[property]);
+          return isNotNANullUndefinedEmptyStringInf(row[property]);
         });
         let notNullValue = null;
         if (notNullObject) {

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -13,7 +13,7 @@ import { omicNavigatorService } from '../../services/omicNavigator.service';
 import ButtonActions from '../Shared/ButtonActions';
 import * as d3 from 'd3';
 import {
-  isNotNANullUndefinedEmptyString,
+  isNotNANullUndefinedEmptyStringInf,
   formatNumberForDisplay,
   splitValue,
   Linkout,
@@ -878,7 +878,7 @@ class Enrichment extends Component {
         // loop through data, one property at a time
         const notNullObject = dataCopy.find((row) => {
           // find the first value for that property
-          return isNotNANullUndefinedEmptyString(row[property]);
+          return isNotNANullUndefinedEmptyStringInf(row[property]);
         });
         let notNullValue = null;
         if (notNullObject) {

--- a/src/components/Enrichment/FilteredDifferentialTable.jsx
+++ b/src/components/Enrichment/FilteredDifferentialTable.jsx
@@ -3,7 +3,7 @@ import { Popup, Dimmer, Loader } from 'semantic-ui-react';
 import { omicNavigatorService } from '../../services/omicNavigator.service';
 import _ from 'lodash-es';
 import {
-  isNotNANullUndefinedEmptyString,
+  isNotNANullUndefinedEmptyStringInf,
   formatNumberForDisplay,
   splitValue,
   Linkout,
@@ -207,7 +207,7 @@ class FilteredDifferentialTable extends Component {
         // loop through data, one property at a time
         const notNullObject = dataCopy.find((row) => {
           // find the first value for that property
-          return isNotNANullUndefinedEmptyString(row[property]);
+          return isNotNANullUndefinedEmptyStringInf(row[property]);
         });
         let notNullValue = null;
         if (notNullObject) {

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -471,10 +471,7 @@ export function getMaxAndMin(data, element) {
       data[i] != null &&
       data[i][element] != null &&
       data[i][element] !== 0 &&
-      data[i][element] !== 'NA' &&
-      data[i][element] !== 'N/A' &&
-      data[i][element] !== 'Inf' &&
-      data[i][element] !== '-Inf'
+      !isNaN(data[i][element])
     ) {
       arrayOfNumbers.push(data[i][element]);
     }

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -463,8 +463,15 @@ export const reviseLayout = (layout, width, height, plotId) => {
   return layoutParsed;
 };
 
-export function isNotNANullUndefinedEmptyString(o) {
-  return typeof o !== 'undefined' && o !== null && o !== 'NA' && o !== '';
+export function isNotNANullUndefinedEmptyStringInf(o) {
+  return (
+    typeof o !== 'undefined' &&
+    o !== null &&
+    o !== 'NA' &&
+    o !== '' &&
+    o !== 'Inf' &&
+    o !== '-Inf'
+  );
 }
 
 /**

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -463,17 +463,23 @@ export const reviseLayout = (layout, width, height, plotId) => {
   return layoutParsed;
 };
 
-export function getMaxAndMin(data, element) {
+export function getMaxAndMin(data, element, doTransform) {
   if (!data.length) return [0, 0];
   const arrayOfNumbers = [];
   for (var i = 1; i < data.length; i++) {
     if (
       data[i] != null &&
       data[i][element] != null &&
-      data[i][element] !== 0 &&
       !isNaN(data[i][element])
     ) {
-      arrayOfNumbers.push(data[i][element]);
+      if (doTransform) {
+        // if doing a -log10 transform, filter out 0's (specific to scaleFactory function)
+        if (data[i][element] != 0) {
+          arrayOfNumbers.push(data[i][element]);
+        }
+      } else {
+        arrayOfNumbers.push(data[i][element]);
+      }
     }
   }
   const min = Math.min(...arrayOfNumbers);

--- a/src/components/Shared/helpers.jsx
+++ b/src/components/Shared/helpers.jsx
@@ -463,11 +463,33 @@ export const reviseLayout = (layout, width, height, plotId) => {
   return layoutParsed;
 };
 
+export function getMaxAndMin(data, element) {
+  if (!data.length) return [0, 0];
+  const arrayOfNumbers = [];
+  for (var i = 1; i < data.length; i++) {
+    if (
+      data[i] != null &&
+      data[i][element] != null &&
+      data[i][element] !== 0 &&
+      data[i][element] !== 'NA' &&
+      data[i][element] !== 'N/A' &&
+      data[i][element] !== 'Inf' &&
+      data[i][element] !== '-Inf'
+    ) {
+      arrayOfNumbers.push(data[i][element]);
+    }
+  }
+  const min = Math.min(...arrayOfNumbers);
+  const max = Math.max(...arrayOfNumbers);
+  return [min, max];
+}
+
 export function isNotNANullUndefinedEmptyStringInf(o) {
   return (
     typeof o !== 'undefined' &&
     o !== null &&
     o !== 'NA' &&
+    o !== 'N/A' &&
     o !== '' &&
     o !== 'Inf' &&
     o !== '-Inf'

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -63,7 +63,7 @@ class Tabs extends Component {
       allStudiesMetadata: [],
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
-      appVersion: '1.8.3',
+      appVersion: '1.8.4',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,


### PR DESCRIPTION
1) When calculating our column types, we find the first value for each column with a value that is not null, and empty string, "NA". "-Inf" and "Inf" were a part of a new study and broke the function, as they can make a numeric column be read as alphanumeric.  Now corrected, "Inf" will show up in the datatable as a blank, since it is not a number.

2) Also, we have a reusable function (**getMaxAndMin**) that is used to create scatterplot axis and determine if an axis can be -log 10 transformed.  That function was creating a min/max array (e.g. [0, 1] based on the values in the first object in the array. However, if the first object has null values or "Inf", the calculation was flawed. **The function has been adjusted to only run a calculation for numbers**.  Additionally, in the instance where we use the function in the scatterplot to determine the axis scale, an additional check has been added to ignore 0's if a -log10 transformation is in effect.

3) Finally, if a scatterplot axis has the ability to run a -log10 transformation, by default.