### PR TITLE
[IPAD-459] always allow multi-feature selection

### DIFF
--- a/src/components/Differential/Differential.jsx
+++ b/src/components/Differential/Differential.jsx
@@ -549,6 +549,7 @@ class Differential extends Component {
       ? id
       : dataItem[differentialFeatureIdKey];
     const self = this;
+    debugger;
     this.setState(
       {
         plotOverlayData: plotOverlayData,
@@ -711,7 +712,7 @@ class Differential extends Component {
                 )
                 .then((svg) => {
                   let xml = svg?.data || null;
-                  if (xml != null && xml !== []) {
+                  if (xml != null && xml.length > 0) {
                     xml = xml.replace(/id="/g, 'id="' + id + '-' + i + '-');
                     xml = xml.replace(/#glyph/g, '#' + id + '-' + i + '-glyph');
                     xml = xml.replace(/#clip/g, '#' + id + '-' + i + '-clip');
@@ -1069,7 +1070,7 @@ class Differential extends Component {
                     //   self.getMultifeaturePlotTransition(featureids, true, i);
                     // } else {
                     let xml = svg?.data || null;
-                    if (xml != null && xml !== []) {
+                    if (xml != null && xml.length > 0) {
                       xml = xml.replace(/id="/g, 'id="' + i + '-');
                       xml = xml.replace(/#glyph/g, '#' + i + '-glyph');
                       xml = xml.replace(/#clip/g, '#' + i + '-clip');
@@ -1330,8 +1331,7 @@ class Differential extends Component {
           let differentialHighlightedFeaturesVar = [];
           if (
             HighlightedFeaturesCopy.length > 0 &&
-            HighlightedFeaturesCopy != null &&
-            HighlightedFeaturesCopy !== {}
+            HighlightedFeaturesCopy != null
           ) {
             HighlightedFeaturesCopy.forEach((element) => {
               differentialHighlightedFeaturesVar.push(element.key);
@@ -1349,8 +1349,7 @@ class Differential extends Component {
         let differentialHighlightedFeaturesVar = [];
         if (
           HighlightedFeaturesCopy.length > 0 &&
-          HighlightedFeaturesCopy != null &&
-          HighlightedFeaturesCopy !== {}
+          HighlightedFeaturesCopy != null
         ) {
           HighlightedFeaturesCopy.forEach((element) => {
             differentialHighlightedFeaturesVar.push(element.key);
@@ -1671,29 +1670,27 @@ class Differential extends Component {
       },
     );
     let checkboxCol = [];
-    if (this.state.plotMultiFeatureAvailable) {
-      checkboxCol = [
-        {
-          title: '',
-          field: 'select',
-          hideOnExport: true,
-          sortDisabled: true,
-          // sortAccessor: (item, field) => console.log(item, field),
-          // self.state.differentialHighlightedFeatures.contains(item),
-          template: (value, item, addParams) => {
-            return (
-              <div className="DifferentialResultsRowCheckboxDiv">
-                <Icon
-                  name="square outline"
-                  size="large"
-                  className="DifferentialResultsRowCheckbox"
-                />
-              </div>
-            );
-          },
+    checkboxCol = [
+      {
+        title: '',
+        field: 'select',
+        hideOnExport: true,
+        sortDisabled: true,
+        // sortAccessor: (item, field) => console.log(item, field),
+        // self.state.differentialHighlightedFeatures.contains(item),
+        template: (value, item, addParams) => {
+          return (
+            <div className="DifferentialResultsRowCheckboxDiv">
+              <Icon
+                name="square outline"
+                size="large"
+                className="DifferentialResultsRowCheckbox"
+              />
+            </div>
+          );
         },
-      ];
-    }
+      },
+    ];
 
     const checkboxAndAlphanumericCols = checkboxCol.concat(
       differentialAlphanumericColumnsMapped,

--- a/src/components/Differential/DifferentialDetail.jsx
+++ b/src/components/Differential/DifferentialDetail.jsx
@@ -413,7 +413,7 @@ class DifferentialDetail extends Component {
             self.props.onResetDifferentialOutlinedFeature();
             self.pageToFeature();
           }
-          if (!doubleClickEvent && plotMultiFeatureAvailable) {
+          if (!doubleClickEvent) {
             // IF MULTI-FEATURE PLOTTING AVAILABLE AND THERE IS DATA
             const highlightedFeaturesLength =
               differentialHighlightedFeatures.length;
@@ -511,7 +511,6 @@ class DifferentialDetail extends Component {
       this.pageToFeature(event[differentialFeatureIdKey]);
       this.props.onGetPlot('SingleFeature', feature, false, false);
     } else {
-      if (!this.props.plotMultiFeatureAvailable) return;
       let elementArray = items.map((item) => ({
         id: item,
         value: item,
@@ -540,6 +539,7 @@ class DifferentialDetail extends Component {
   };
 
   reloadMultifeaturePlot = _.debounce((selected, boxSelection) => {
+    if (!this.props.plotMultiFeatureAvailable) return;
     const data = boxSelection
       ? selected
       : this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.getSortedData() ||
@@ -597,7 +597,6 @@ class DifferentialDetail extends Component {
       differentialHighlightedFeaturesData,
       differentialResults,
     } = this.props;
-    const { plotMultiFeatureAvailable } = this.props;
     event.persist();
     event.stopPropagation();
     this.setState({
@@ -628,7 +627,6 @@ class DifferentialDetail extends Component {
       }
       if (event.shiftKey) {
         // SHIFT CLICK - ADD MULTIPLE FEATURES
-        if (!plotMultiFeatureAvailable) return;
         const currentTableData =
           this.volcanoPlotFilteredGridRef?.current?.qhGridRef.current?.getSortedData() ||
           [];
@@ -672,7 +670,6 @@ class DifferentialDetail extends Component {
         event?.target?.innerHTML.includes('DifferentialResultsRowCheckboxDiv')
       ) {
         // CONTROL CLICK OR CLICK IN CHECKBOX CELL CLICK - ADD/REMOVE ONE FEATURE
-        if (!plotMultiFeatureAvailable) return;
         // control-click or click specifically on checkbox
         const currentTableData =
           this.volcanoPlotFilteredGridRef?.current?.qhGridRef.current?.getSortedData() ||
@@ -908,44 +905,42 @@ class DifferentialDetail extends Component {
             this.props.onResetDifferentialOutlinedFeature();
             this.pageToFeature();
           }
-          if (this.props.plotMultiFeatureAvailable) {
-            // IF MULTI-FEATURE PLOTTING AVAILABLE AND THERE IS DATA
-            let multiselectedFeaturesArrRemaining = [
-              ...sortedFilteredData,
-            ].filter((item) =>
-              self.props.differentialHighlightedFeatures.includes(
-                item[self.props.differentialFeatureIdKey],
-              ),
-            );
-            if (
-              self.props.differentialHighlightedFeatures.length !==
-              multiselectedFeaturesArrRemaining.length
-            ) {
-              // IF CHECKED FEATURES LENGTH IS DIFFERENT THAN EXISTING
-              if (multiselectedFeaturesArrRemaining.length) {
-                // IF CHECKED FEATURES REMAIN, GET NEW SVG
-                let multiselectedFeaturesArrMappedRemaining = [
-                  ...multiselectedFeaturesArrRemaining,
-                ].map((item) => ({
-                  id: item[self.props.differentialFeatureIdKey],
-                  value: item[self.props.differentialFeatureIdKey],
-                  key: item[self.props.differentialFeatureIdKey],
-                }));
-                this.props.onHandleHighlightedFeaturesDifferential(
-                  multiselectedFeaturesArrMappedRemaining,
-                  true,
-                );
-                let multiselectedFeatureIdsMappedRemaining = [
-                  ...multiselectedFeaturesArrRemaining,
-                ].map((item) => item[self.props.differentialFeatureIdKey]);
-                this.reloadMultifeaturePlot(
-                  multiselectedFeatureIdsMappedRemaining,
-                  true,
-                );
-              } else {
-                // no highlighted after table filter
-                this.props.onHandleHighlightedFeaturesDifferential([]);
-              }
+          // IF MULTI-FEATURE PLOTTING AVAILABLE AND THERE IS DATA
+          let multiselectedFeaturesArrRemaining = [
+            ...sortedFilteredData,
+          ].filter((item) =>
+            self.props.differentialHighlightedFeatures.includes(
+              item[self.props.differentialFeatureIdKey],
+            ),
+          );
+          if (
+            self.props.differentialHighlightedFeatures.length !==
+            multiselectedFeaturesArrRemaining.length
+          ) {
+            // IF CHECKED FEATURES LENGTH IS DIFFERENT THAN EXISTING
+            if (multiselectedFeaturesArrRemaining.length) {
+              // IF CHECKED FEATURES REMAIN, GET NEW SVG
+              let multiselectedFeaturesArrMappedRemaining = [
+                ...multiselectedFeaturesArrRemaining,
+              ].map((item) => ({
+                id: item[self.props.differentialFeatureIdKey],
+                value: item[self.props.differentialFeatureIdKey],
+                key: item[self.props.differentialFeatureIdKey],
+              }));
+              this.props.onHandleHighlightedFeaturesDifferential(
+                multiselectedFeaturesArrMappedRemaining,
+                true,
+              );
+              let multiselectedFeatureIdsMappedRemaining = [
+                ...multiselectedFeaturesArrRemaining,
+              ].map((item) => item[self.props.differentialFeatureIdKey]);
+              this.reloadMultifeaturePlot(
+                multiselectedFeatureIdsMappedRemaining,
+                true,
+              );
+            } else {
+              // no highlighted after table filter
+              this.props.onHandleHighlightedFeaturesDifferential([]);
             }
           }
         } else {
@@ -986,6 +981,7 @@ class DifferentialDetail extends Component {
   };
 
   getMultifeaturePlotTransitionAlt = () => {
+    if (!this.props.plotMultiFeatureAvailable) return;
     const tableData =
       this.volcanoPlotFilteredGridRef?.current?.qhGridRef?.current?.getSortedData() ||
       this.props.differentialResults;
@@ -1389,7 +1385,6 @@ class DifferentialDetail extends Component {
       plotSingleFeatureData,
       plotSingleFeatureDataLength,
       plotSingleFeatureDataLoaded,
-      plotMultiFeatureAvailable,
       plotMultiFeatureData,
       plotMultiFeatureDataLength,
       plotMultiFeatureDataLoaded,
@@ -2082,32 +2077,24 @@ class DifferentialDetail extends Component {
                         </div>
                         <Grid.Column
                           className="ResultsTableWrapper"
-                          id={
-                            plotMultiFeatureAvailable
-                              ? 'DifferentialResultsTableWrapperCheckboxes'
-                              : 'DifferentialResultsTableWrapper'
-                          }
+                          id="DifferentialResultsTableWrapperCheckboxes"
                           mobile={16}
                           tablet={16}
                           largeScreen={16}
                           widescreen={16}
                         >
-                          {plotMultiFeatureAvailable ? (
-                            <>
-                              <Popup
-                                trigger={
-                                  <Icon
-                                    name="info"
-                                    id="ToggleAllCheckboxInfo"
-                                  />
-                                }
-                                style={selectAllPopupStyle}
-                                // content="Row is light orange when the feature is selected"
-                                content={SelectAllPopupContent}
-                                inverted
-                                basic
-                              />
-                              {/* <Icon
+                          <>
+                            <Popup
+                              trigger={
+                                <Icon name="info" id="ToggleAllCheckboxInfo" />
+                              }
+                              style={selectAllPopupStyle}
+                              // content="Row is light orange when the feature is selected"
+                              content={SelectAllPopupContent}
+                              inverted
+                              basic
+                            />
+                            {/* <Icon
                                 name={
                                   allChecked ? 'check square' : 'square outline'
                                 }
@@ -2116,8 +2103,7 @@ class DifferentialDetail extends Component {
                                 className={allChecked ? 'PrimaryColor' : ''}
                                 onClick={this.toggleAllCheckboxes}
                               /> */}
-                            </>
-                          ) : null}
+                          </>
                           {table}
                         </Grid.Column>
                       </Grid.Row>

--- a/src/components/Differential/ScatterPlot.jsx
+++ b/src/components/Differential/ScatterPlot.jsx
@@ -1583,8 +1583,7 @@ class ScatterPlot extends Component {
   }
 
   mapBoxSelectionToHighlight(total) {
-    const { plotMultiFeatureAvailable, differentialFeatureIdKey } = this.props;
-    if (!plotMultiFeatureAvailable) return null;
+    const { differentialFeatureIdKey } = this.props;
     const scatterArr = total.map((item) => ({
       id: item[differentialFeatureIdKey],
       value: item[differentialFeatureIdKey],

--- a/src/components/Differential/ScatterPlotDiv.jsx
+++ b/src/components/Differential/ScatterPlotDiv.jsx
@@ -570,18 +570,16 @@ class ScatterPlotDiv extends Component {
                       </List.Description>
                     </List.Content>
                   </List.Item>
-                  {plotMultiFeatureAvailable ? (
-                    <List.Item>
-                      <Icon name="circle" id="SelectedCircleIcon" />
-                      <List.Content>
-                        <List.Header>Plot Multiple Features</List.Header>
-                        <List.Description>
-                          Control-click circle/s, or hold Shift while
-                          box-selecting (orange fill)
-                        </List.Description>
-                      </List.Content>
-                    </List.Item>
-                  ) : null}
+                  <List.Item>
+                    <Icon name="circle" id="SelectedCircleIcon" />
+                    <List.Content>
+                      <List.Header>Select Multiple Features</List.Header>
+                      <List.Description>
+                        Control-click circle/s, or hold Shift while
+                        box-selecting (orange fill)
+                      </List.Description>
+                    </List.Content>
+                  </List.Item>
                 </List>
               </Popup.Content>
             </Popup>

--- a/src/components/Enrichment/Enrichment.jsx
+++ b/src/components/Enrichment/Enrichment.jsx
@@ -561,7 +561,7 @@ class Enrichment extends Component {
             return valid;
           },
         );
-        let plotMultiFeatureAvailableVar = false;
+        // let plotMultiFeatureAvailableVar = false;
         // let singleFeaturePlotTypesVar = [];
         let multiFeaturePlotTypesVar = [];
         if (enrichmentPlotTypesVar) {
@@ -571,13 +571,13 @@ class Enrichment extends Component {
           multiFeaturePlotTypesVar = [...enrichmentPlotTypesVar].filter((p) =>
             p.plotType.includes('multiFeature'),
           );
-          plotMultiFeatureAvailableVar = multiFeaturePlotTypesVar?.length
-            ? true
-            : false;
+          // plotMultiFeatureAvailableVar = multiFeaturePlotTypesVar?.length
+          //   ? true
+          //   : false;
         }
         this.setState({
           enrichmentPlotTypes: enrichmentPlotTypesVar,
-          plotMultiFeatureAvailable: plotMultiFeatureAvailableVar,
+          // plotMultiFeatureAvailable: plotMultiFeatureAvailableVar,
         });
       }
     }


### PR DESCRIPTION
Adjustment allows for multi-feature selection on scatter plot and data table (in the differential tab), even if that study does not have multi-feature plots.  To test, interact with the scatter plot and table for studies with (example study) and without multi-feature plots.