### PR TITLE
[IPAD-478] - Landing Page for Smaller Devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omicnavigatorwebapp",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "dependencies": {
         "@observablehq/stdlib": "^5.6.1",
         "array-move": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omicnavigatorwebapp",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "private": true,
   "dependencies": {
     "@observablehq/stdlib": "^5.6.1",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "OmicNavigator",
   "name": "OmicNavigator",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -435,3 +435,37 @@
     font-size: 18px;
   }
 }
+
+#SmallScreenOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 1);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+  color: white !important;
+  #SmallScreenLogoImage {
+    height: 46px;
+  }
+
+  #SmallScreenHeaderFirst {
+    font-size: 36px;
+  }
+
+  #SmallScreenHeaderSecond {
+    font-size: 36px;
+    font-weight: 100 !important;
+    font-style: italic;
+    color: #e0e1e2 !important;
+  }
+
+  #SmallScreenText {
+    width: 80%;
+    font-size: 18px !important;
+  }
+}

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -64,7 +64,7 @@ class Tabs extends Component {
       differentialFeatureIdKey: '',
       filteredDifferentialFeatureIdKey: '',
       // when updating the app version, change one line in 3 files: package.json, manifest.json and Tabs.jsx
-      appVersion: '1.8.8',
+      appVersion: '1.8.9',
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -371,7 +371,7 @@ class Tabs extends Component {
         <span id="SmallScreenHeaderSecond">Navigator</span>
         <span id="SmallScreenText">
           For an optimal experience, Omic Navigator is best viewed on screens
-          wider than 1024+ pixels. Your screen is {screenWidth} pixels wide.
+          1024+ pixels wide. Your screen is {screenWidth} pixels wide.
         </span>
       </span>
     );

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -68,7 +68,9 @@ class Tabs extends Component {
       packageVersion: '',
       infoOpenFirst: false,
       infoOpenSecond: false,
+      screenWidth: window.innerWidth,
     };
+    this.handleResize = this.handleResize.bind(this);
   }
 
   componentDidMount() {
@@ -82,6 +84,19 @@ class Tabs extends Component {
       null,
     );
     this.getStudies();
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    // Remove the event listener when the component is unmounted
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  handleResize() {
+    // Update the state with the new screen width when the resize event occurs
+    this.setState({
+      screenWidth: window.innerWidth,
+    });
   }
 
   setTabIndex = (tabIndex) => {
@@ -341,6 +356,27 @@ class Tabs extends Component {
     );
   };
 
+  getSmallScreenMessage = () => {
+    const { screenWidth } = this.state;
+    return (
+      <span id="SmallScreenOverlay">
+        <span className="LogoElement">
+          <img
+            alt="OmicNavigator"
+            src={omicNavigatorIcon}
+            id="SmallScreenLogoImage"
+          />
+        </span>
+        <span id="SmallScreenHeaderFirst">Omic</span>
+        <span id="SmallScreenHeaderSecond">Navigator</span>
+        <span id="SmallScreenText">
+          For an optimal experience, Omic Navigator is best viewed on screens
+          wider than 1024+ pixels. Your screen is {screenWidth} pixels wide.
+        </span>
+      </span>
+    );
+  };
+
   resetApp = () => {
     this.setState(
       {
@@ -375,7 +411,7 @@ class Tabs extends Component {
   };
 
   render() {
-    const { activeIndex } = this.state;
+    const { activeIndex, screenWidth } = this.state;
     const panes = [
       {
         menuItem: (
@@ -431,8 +467,10 @@ class Tabs extends Component {
       },
     ];
     const InfoButton = this.getInfoButton();
+    const SmallScreenMessage = this.getSmallScreenMessage();
     return (
       <>
+        {screenWidth < 1024 ? SmallScreenMessage : null}
         <Tab
           onTabChange={this.handleTabChange}
           panes={panes}


### PR DESCRIPTION
Display an overlay when the screen width is under 1024 pixels, so users do not have a substandard experience on small devices.

<img width="372" alt="mobile" src="https://github.com/abbvie-external/OmicNavigatorWebApp/assets/10191004/7cb7c2f3-3e3a-4798-a416-eced409615d8">